### PR TITLE
Fix error by adding .toarray() if dims > 1

### DIFF
--- a/sfaira/estimators/keras.py
+++ b/sfaira/estimators/keras.py
@@ -1001,24 +1001,24 @@ class EstimatorKerasCelltype(EstimatorKeras):
         :param weighted: Whether to use weights.
         :return:
         """
-        if mode == 'train':
+        if mode == 'train' or mode == 'train_val':
             weights, y = self._get_celltype_out(idx=idx)
             if not weighted:
                 weights = np.ones_like(weights)
 
-            if self.data.filename is None:
+            if self.data.isbacked:
+                n_features = self.data.X.shape[1]
+
+                def generator():
+                    for i, ii in enumerate(idx):
+                        yield np.asarray(self.data.X[ii, :]).flatten(), y[i, :], weights[i]
+            else:
                 x = self._prepare_data_matrix(idx=idx)
                 n_features = x.shape[1]
 
                 def generator():
                     for i, ii in enumerate(idx):
                         yield x[i, :].toarray().flatten(), y[i, :], weights[i]
-            else:
-                n_features = self.data.X.shape[1]
-
-                def generator():
-                    for i, ii in enumerate(idx):
-                        yield np.asarray(self.data.X[ii, :]).flatten(), y[i, :], weights[i]
 
             dataset = tf.data.Dataset.from_generator(
                 generator=generator,
@@ -1029,71 +1029,33 @@ class EstimatorKerasCelltype(EstimatorKeras):
                     tf.TensorShape([])
                 )
             )
-            dataset = dataset.repeat().shuffle(
-                buffer_size=min(x.shape[0], shuffle_buffer_size),
-                seed=None,
-                reshuffle_each_iteration=True
-            ).batch(batch_size).prefetch(prefetch)
-            return dataset
-        elif mode == 'train_val':
-            weights, y = self._get_celltype_out(idx=idx)
-            if not weighted:
-                weights = np.ones_like(weights)
-
-            if self.data.filename is None:
-                x = self._prepare_data_matrix(idx=idx)
-                n_features = x.shape[1]
-
-                def generator():
-                    for i, ii in enumerate(idx):
-                        yield x[i, :].toarray().flatten(), y[i, :], weights[i]
-            else:
-                n_features = self.data.X.shape[1]
-
-                def generator():
-                    for i, ii in enumerate(idx):
-                        yield np.asarray(self.data.X[ii, :]).flatten(), y[i, :], weights[i]
-
-            dataset = tf.data.Dataset.from_generator(
-                generator=generator,
-                output_types=(tf.float32, tf.float32, tf.float32),
-                output_shapes=(
-                    (tf.TensorShape([n_features])),
-                    tf.TensorShape([y.shape[1]]),
-                    tf.TensorShape([])
-                )
-            )
+            if mode == 'train':
+                dataset = dataset.repeat()
             dataset = dataset.shuffle(
                 buffer_size=min(x.shape[0], shuffle_buffer_size),
                 seed=None,
                 reshuffle_each_iteration=True
             ).batch(batch_size).prefetch(prefetch)
+
             return dataset
-        elif mode == 'predict':
-            # Prepare data reading according to whether anndata is backed or not:
-            if self.data.filename is None:
-                x = self._prepare_data_matrix(idx=idx)
-                x = x.toarray()
-            else:
-                # Need to supply sorted indices to backed anndata:
-                x = self.data.X[np.sort(idx), :]
-                # Sort back in original order of indices.
-                x = x[np.argsort(idx), :]
-            return x, None, None
-        elif mode == 'eval':
+
+        elif mode == 'eval' or mode == 'predict':
             weights, y = self._get_celltype_out(idx=idx)
             if not weighted:
                 weights = np.ones_like(weights)
+
             # Prepare data reading according to whether anndata is backed or not:
-            if self.data.filename is None:
-                x = self._prepare_data_matrix(idx=idx)
-                x = x.toarray()
-            else:
+            if self.data.isbacked:
                 # Need to supply sorted indices to backed anndata:
                 x = self.data.X[np.sort(idx), :]
                 # Sort back in original order of indices.
                 x = x[np.argsort(idx), :]
+            else:
+                x = self._prepare_data_matrix(idx=idx)
+                x = x.toarray()
+
             return x, y, weights
+
         else:
             raise ValueError(f'Mode {mode} not recognised. Should be "train", "eval" or" predict"')
 

--- a/sfaira/estimators/keras.py
+++ b/sfaira/estimators/keras.py
@@ -1010,8 +1010,10 @@ class EstimatorKerasCelltype(EstimatorKeras):
                 n_features = self.data.X.shape[1]
 
                 def generator():
+                    sparse = isinstance(self.data.X[0, :], scipy.sparse.spmatrix)
                     for i, ii in enumerate(idx):
-                        yield np.asarray(self.data.X[ii, :]).flatten(), y[i, :], weights[i]
+                        x = self.data.X[ii, :].toarray().flatten() if sparse else self.data.X[ii, :].flatten()
+                        yield x, y[i, :], weights[i]
             else:
                 x = self._prepare_data_matrix(idx=idx)
                 n_features = x.shape[1]

--- a/sfaira/estimators/keras.py
+++ b/sfaira/estimators/keras.py
@@ -553,13 +553,15 @@ class EstimatorKerasEmbedding(EstimatorKeras):
                     def generator():
                         for i in idx:
                             # (_,_), (_,sf) is dummy for kl loss
-                            x = self.data.X[i, :].flatten()
+                            raw_sample = self.data.X[i, :]
+                            x = raw_sample.toarray().flatten() if raw_sample.ndim == 2 else raw_sample.flatten()
                             sf = self._prepare_sf(x=x)[0]
                             yield (x, sf), (x, sf)
                 else:
                     def generator():
                         for i in idx:
-                            x = self.data.X[i, :].flatten()
+                            raw_sample = self.data.X[i, :]
+                            x = raw_sample.toarray().flatten() if raw_sample.ndim == 2 else raw_sample.flatten()
                             sf = self._prepare_sf(x=x)[0]
                             yield (x, sf), x
             else:
@@ -618,7 +620,8 @@ class EstimatorKerasEmbedding(EstimatorKeras):
                 def generator():
                     for i in idx:
                         # (_,_), (_,sf) is dummy for kl loss
-                        x = self.data.X[i, :].flatten()
+                        raw_sample = self.data.X[i, :]
+                        x = raw_sample.toarray().flatten() if raw_sample.ndim == 2 else raw_sample.flatten()
                         sf = self._prepare_sf(x=x)[0]
                         y = self.data.obs['cell_ontology_class'][i]
                         yield (x, sf), (x, cell_to_class[y])

--- a/sfaira/estimators/keras.py
+++ b/sfaira/estimators/keras.py
@@ -551,17 +551,17 @@ class EstimatorKerasEmbedding(EstimatorKeras):
 
                 if model_type == "vae":
                     def generator():
+                        sparse = isinstance(self.data.X[0, :], scipy.sparse.spmatrix)
                         for i in idx:
                             # (_,_), (_,sf) is dummy for kl loss
-                            raw_sample = self.data.X[i, :]
-                            x = raw_sample.toarray().flatten() if raw_sample.ndim == 2 else raw_sample.flatten()
+                            x = self.data.X[i, :].toarray().flatten() if sparse else self.data.X[i, :].flatten()
                             sf = self._prepare_sf(x=x)[0]
                             yield (x, sf), (x, sf)
                 else:
                     def generator():
+                        sparse = isinstance(self.data.X[0, :], scipy.sparse.spmatrix)
                         for i in idx:
-                            raw_sample = self.data.X[i, :]
-                            x = raw_sample.toarray().flatten() if raw_sample.ndim == 2 else raw_sample.flatten()
+                            x = self.data.X[i, :].toarray().flatten() if sparse else self.data.X[i, :].flatten()
                             sf = self._prepare_sf(x=x)[0]
                             yield (x, sf), x
             else:
@@ -618,10 +618,9 @@ class EstimatorKerasEmbedding(EstimatorKeras):
                 output_types, output_shapes = self._get_output_dim(n_features, 'vae')
 
                 def generator():
+                    sparse = isinstance(self.data.X[0, :], scipy.sparse.spmatrix)
                     for i in idx:
-                        # (_,_), (_,sf) is dummy for kl loss
-                        raw_sample = self.data.X[i, :]
-                        x = raw_sample.toarray().flatten() if raw_sample.ndim == 2 else raw_sample.flatten()
+                        x = self.data.X[i, :].toarray().flatten() if sparse else self.data.X[i, :].flatten()
                         sf = self._prepare_sf(x=x)[0]
                         y = self.data.obs['cell_ontology_class'][i]
                         yield (x, sf), (x, cell_to_class[y])


### PR DESCRIPTION
Backed mode throws an error depending on the shape of the data object. This fix checks for both variations and flattens accordingly.