### PR TITLE
Explicitly cast indices and indptr of final backed file to int64.

### DIFF
--- a/sfaira/data/base.py
+++ b/sfaira/data/base.py
@@ -816,7 +816,10 @@ class DatasetSuperGroup:
         self.adata.filename = fn_backed  # setting this attribute switches this anndata to a backed object
         # Note that setting .filename automatically redefines .X as dense, so we have to redefine it as sparse:
         if not as_dense:
-            self.adata.X = scipy.sparse.csr_matrix(self.adata.X)  # redefines this backed anndata as sparse
+            X = scipy.sparse.csr_matrix(self.adata.X)  # redefines this backed anndata as sparse
+            X.indices = X.indices.astype(np.int64)
+            X.indptr = X.indptr.astype(np.int64)
+            self.adata.X = X
         keys = [
             "lab",
             "year",


### PR DESCRIPTION
Due to the `indices` and `indptr` values for backed files being `int32` by default, an overflow occurs when writing larger files limiting backed file data size to `2147483647 ` non-negative values. By casting these two attributes to `int64`, we can write much larger files.