### PR TITLE
Implementation of test-dataloader

### DIFF
--- a/docs/adding_datasets.rst
+++ b/docs/adding_datasets.rst
@@ -265,7 +265,7 @@ The common workflow look as follows:
 
 1. Create a new dataloader with ``sfaira create-dataloader``
 2. Validate the dataloader with ``sfaira lint-dataloader <path>``
-3. Test the dataloader with ``sfaira test-dataloader . --doi <doi>``
+3. Test the dataloader with ``sfaira test-dataloader . --doi <doi> --test-data <folder_above_test_data>``
 
 When creating a dataloader with ``sfaira create-dataloader`` common information such as
 your name and email are prompted for, followed by dataloader specific attributes such as organ, organism and many more.
@@ -289,8 +289,25 @@ All unused attributes will be removed.
 Next validate the integrity of your dataloader content with ``sfaira lint-dataloader <path to *.yaml>``.
 All tests must pass! If any of the tests fail please revisit your dataloader and add the missing information.
 
-Finally, copy your dataloader into the ``sfaira/dataloaders/loaders/`` folder and your test data into ``sfaira/unit_tests/template_data/``.
-Now you can test your dataloader with ``sfaira test-dataloader <path_to_sfaira> --doi <doi>``. 
+Finally, copy your dataloader into the ``sfaira/dataloaders/loaders/`` folder.
+Now you can test your dataloader with ``sfaira test-dataloader <path_to_sfaira> --doi <doi> --test-data <template_data_folder>``.
+Note that sfaira expects a folder structure for the test data such as:
+
+.. code-block::
+
+    ├── template_data
+    │   └── d10_1016_j_cmet_2019_01_021
+    │       ├── GSE117770_RAW.tar
+    │       ├── GSM3308545_NOD_08w_A_annotation.csv
+    │       ├── GSM3308547_NOD_08w_C_annotation.csv
+    │       ├── GSM3308548_NOD_14w_A_annotation.csv
+    │       ├── GSM3308549_NOD_14w_B_annotation.csv
+    │       ├── GSM3308550_NOD_14w_C_annotation.csv
+    │       ├── GSM3308551_NOD_16w_A_annotation.csv
+    │       ├── GSM3308552_NOD_16w_B_annotation.csv
+    │       └── GSM3308553_NOD_16w_C_annotation.csv
+
+Pass the path to the template_data folder, not the doi. Sfaira will use this path to cache further data for speedups.
 All tests must pass! If any of the tests fail please revisit your dataloader and fix the error.
 
 Map cell type labels to ontology

--- a/docs/adding_datasets.rst
+++ b/docs/adding_datasets.rst
@@ -54,7 +54,7 @@ The data loader python file
 
 Each data set, ie a single file or a set of files with similar structures, has its own data loader function and a yaml
 files that describes its meta data.
-Alternatively to the (preffered) yaml file, meta data can be also be described in a constructor of a class in the same python file
+Alternatively to the (preferred) yaml file, meta data can be also be described in a constructor of a class in the same python file
 as the loading function. For a documentation on writing a python class-based dataloader, please see here: https://github.com/theislab/sfaira/blob/dev/docs/adding_dataset_classes.rst
 A detailed description of all meta data is given at the bottom of this page.
 
@@ -265,6 +265,7 @@ The common workflow look as follows:
 
 1. Create a new dataloader with ``sfaira create-dataloader``
 2. Validate the dataloader with ``sfaira lint-dataloader <path>``
+3. Test the dataloader with ``sfaira test-dataloader . --doi <doi>``
 
 When creating a dataloader with ``sfaira create-dataloader`` common information such as
 your name and email are prompted for, followed by dataloader specific attributes such as organ, organism and many more.

--- a/docs/adding_datasets.rst
+++ b/docs/adding_datasets.rst
@@ -289,6 +289,10 @@ All unused attributes will be removed.
 Next validate the integrity of your dataloader content with ``sfaira lint-dataloader <path to *.yaml>``.
 All tests must pass! If any of the tests fail please revisit your dataloader and add the missing information.
 
+Finally, copy your dataloader into the ``sfaira/dataloaders/loaders/`` folder and your test data into ``sfaira/unit_tests/template_data/``.
+Now you can test your dataloader with ``sfaira test-dataloader <path_to_sfaira> --doi <doi>``. 
+All tests must pass! If any of the tests fail please revisit your dataloader and fix the error.
+
 Map cell type labels to ontology
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/sfaira/cli.py
+++ b/sfaira/cli.py
@@ -104,13 +104,14 @@ def lint_dataloader(path) -> None:
 
 @sfaira_cli.command()
 @click.argument('path', type=click.Path(exists=True))
+@click.option('--test-data', type=click.Path(exists=True))
 @click.option('--doi', type=str, default=None)
-def test_dataloader(path, doi) -> None:
+def test_dataloader(path, test_data, doi) -> None:
     """Runs a dataloader integration test.
 
     PATH is the absolute path of the root of your sfaira clone.
     """
-    dataloader_tester = DataloaderTester(path, doi)
+    dataloader_tester = DataloaderTester(path, test_data, doi)
     dataloader_tester.test_dataloader()
 
 

--- a/sfaira/cli.py
+++ b/sfaira/cli.py
@@ -104,11 +104,13 @@ def lint_dataloader(path) -> None:
 
 @sfaira_cli.command()
 @click.argument('path', type=click.Path(exists=True))
-def test_dataloader(path) -> None:
+@click.option('--doi', type=str, default=None)
+def test_dataloader(path, doi) -> None:
+    """Runs a dataloader integration test.
+
+    PATH is the absolute path of the root of your sfaira clone.
     """
-    Runs a dataloader unit test.
-    """
-    dataloader_tester = DataloaderTester(path)
+    dataloader_tester = DataloaderTester(path, doi)
     dataloader_tester.test_dataloader()
 
 

--- a/sfaira/commands/test_dataloader.py
+++ b/sfaira/commands/test_dataloader.py
@@ -43,8 +43,6 @@ class DataloaderTester:
 
         os.chdir(f'{self.path}/sfaira/unit_tests/data_contribution')
 
-        # the DOI to enter should be 10.1016.j.cmet.2019.01.021
-
         pytest = Popen(['pytest', 'test_data_template.py', '--doi_sfaira_repr', self.doi_sfaira_repr],
                        universal_newlines=True, shell=False, close_fds=True)
         (pytest_stdout, pytest_stderr) = pytest.communicate()
@@ -53,5 +51,4 @@ class DataloaderTester:
         if pytest_stderr:
             print(pytest_stderr)
 
-        # Switch back to the current working directory
         os.chdir(self.cwd)

--- a/sfaira/commands/test_dataloader.py
+++ b/sfaira/commands/test_dataloader.py
@@ -23,7 +23,6 @@ class DataloaderTester:
         Runs a predefined unit test on a given dataloader.
         """
         print('[bold blue]Please ensure that your dataloader is in sfaira/dataloaders/loaders/<doi_flattened>.')
-        print('[bold blue]Please ensure that your test data is in sfaira/unit_tests/template_data/<doi_flattened>.')
         if not self.doi:
             self._prompt_doi()
         self.doi_sfaira_repr = f'd{self.doi.translate({ord(c): "_" for c in r"!@#$%^&*()[]/{};:,.<>?|`~-=_+"})}'
@@ -44,7 +43,7 @@ class DataloaderTester:
 
         os.chdir(f'{self.path}/sfaira/unit_tests/data_contribution')
 
-        pytest = Popen(['pytest', 'test_data_template.py', '--doi_sfaira_repr', self.doi_sfaira_repr],
+        pytest = Popen(['pytest', 'test_data_template.py', '--doi_sfaira_repr', self.doi_sfaira_repr, '--test_data', self.test_data],
                        universal_newlines=True, shell=False, close_fds=True)
         (pytest_stdout, pytest_stderr) = pytest.communicate()
         if pytest_stdout:

--- a/sfaira/commands/test_dataloader.py
+++ b/sfaira/commands/test_dataloader.py
@@ -10,9 +10,10 @@ log = logging.getLogger(__name__)
 
 class DataloaderTester:
 
-    def __init__(self, path, doi):
+    def __init__(self, path, test_data, doi):
         self.WD = os.path.dirname(__file__)
         self.path = path
+        self.test_data = test_data
         self.cwd = os.getcwd()
         self.doi = doi
         self.doi_sfaira_repr = ''

--- a/sfaira/commands/test_dataloader.py
+++ b/sfaira/commands/test_dataloader.py
@@ -10,33 +10,48 @@ log = logging.getLogger(__name__)
 
 class DataloaderTester:
 
-    def __init__(self, path):
+    def __init__(self, path, doi):
         self.WD = os.path.dirname(__file__)
         self.path = path
-        self.doi = ''
+        self.cwd = os.getcwd()
+        self.doi = doi
         self.doi_sfaira_repr = ''
 
     def test_dataloader(self):
         """
         Runs a predefined unit test on a given dataloader.
         """
-        print('[bold red]This command is currently disabled.')
-        # print('[bold blue]Please ensure that your dataloader is in sfaira/dataloaders/loaders/<doi_flattened>.')
-        # print('[bold blue]Please ensure that your test data is in sfaira/unit_tests/template_data/<doi_flattened>.')
-        # self._prompt_doi()
-        # self._run_unittest()
+        print('[bold blue]Please ensure that your dataloader is in sfaira/dataloaders/loaders/<doi_flattened>.')
+        print('[bold blue]Please ensure that your test data is in sfaira/unit_tests/template_data/<doi_flattened>.')
+        if not self.doi:
+            self._prompt_doi()
+        self.doi_sfaira_repr = f'd{self.doi.translate({ord(c): "_" for c in r"!@#$%^&*()[]/{};:,.<>?|`~-=_+"})}'
+        self._run_unittest()
 
     def _prompt_doi(self):
         self.doi = sfaira_questionary(function='text',
                                       question='Enter your DOI',
                                       default='10.1000/j.journal.2021.01.001')
-        self.doi_sfaira_repr = f'd{self.doi.translate({ord(c): "_" for c in r"!@#$%^&*()[]/{};:,.<>?|`~-=_+"})}'
 
     def _run_unittest(self):
+        """
+        Runs the actual integration test by invoking pytest on it.
+        """
         print('[bold blue]Conflicts are not automatically resolved.')
         print('[bold blue]Please go back to [bold]https://www.ebi.ac.uk/ols/ontologies/cl[blue] for every mismatch or conflicts '
               'and add the correct cell ontology class name into the .csv "target" column.')
-        pytest = Popen(['pytest', '-s', self.path, '--doi_sfaira_repr', self.doi_sfaira_repr],
+
+        os.chdir(f'{self.path}/sfaira/unit_tests/data_contribution')
+
+        # the DOI to enter should be 10.1016.j.cmet.2019.01.021
+
+        pytest = Popen(['pytest', 'test_data_template.py', '--doi_sfaira_repr', self.doi_sfaira_repr],
                        universal_newlines=True, shell=False, close_fds=True)
         (pytest_stdout, pytest_stderr) = pytest.communicate()
-        print(pytest_stderr)
+        if pytest_stdout:
+            print(pytest_stdout)
+        if pytest_stderr:
+            print(pytest_stderr)
+
+        # Switch back to the current working directory
+        os.chdir(self.cwd)

--- a/sfaira/unit_tests/conftest.py
+++ b/sfaira/unit_tests/conftest.py
@@ -1,0 +1,13 @@
+from pytest import fixture
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--doi_sfaira_repr",
+        action="store"
+    )
+
+
+@fixture()
+def doi_sfaira_repr(request):
+    return request.config.getoption("--doi_sfaira_repr")

--- a/sfaira/unit_tests/conftest.py
+++ b/sfaira/unit_tests/conftest.py
@@ -6,8 +6,17 @@ def pytest_addoption(parser):
         "--doi_sfaira_repr",
         action="store"
     )
+    parser.addoption(
+        "--test_data",
+        action="store"
+    )
 
 
 @fixture()
 def doi_sfaira_repr(request):
     return request.config.getoption("--doi_sfaira_repr")
+
+
+@fixture()
+def test_data(request):
+    return request.config.getoption("--test_data")

--- a/sfaira/unit_tests/data_contribution/test_data_template.py
+++ b/sfaira/unit_tests/data_contribution/test_data_template.py
@@ -9,7 +9,7 @@ except ImportError:
     sfairae = None
 
 
-def test_load(doi_sfaira_repr, dir_template: str = "../template_data"):
+def test_load(doi_sfaira_repr: str, test_data: str):
     """
     Unit test to assist with data set contribution.
 
@@ -57,9 +57,9 @@ def test_load(doi_sfaira_repr, dir_template: str = "../template_data"):
 
     ds = DatasetGroupDirectoryOriented(
         file_base=file_path,
-        data_path=dir_template,
-        meta_path=dir_template,
-        cache_path=dir_template
+        data_path=test_data,
+        meta_path=test_data,
+        cache_path=test_data
     )
     # Test raw loading and caching:
     # You can set load_raw to True while debugging when caching works already to speed the test up,
@@ -70,7 +70,7 @@ def test_load(doi_sfaira_repr, dir_template: str = "../template_data"):
         load_raw=True,  # tests raw loading
         allow_caching=True,  # tests caching
     )
-    assert len(ds.ids) > 0, f"no data sets loaded, make sure raw data is in {dir_template}"
+    assert len(ds.ids) > 0, f"no data sets loaded, make sure raw data is in {test_data}"
     # Create cell type conversion table:
     cwd = os.path.dirname(file_path)
     dataset_module = str(cwd.split("/")[-1])
@@ -116,9 +116,9 @@ def test_load(doi_sfaira_repr, dir_template: str = "../template_data"):
                 if DatasetFound is None:
                     datasets_f = [
                         DatasetBase(
-                            data_path=dir_template,
-                            meta_path=dir_template,
-                            cache_path=dir_template,
+                            data_path=test_data,
+                            meta_path=test_data,
+                            cache_path=test_data,
                             load_func=load_func,
                             dict_load_func_annotation=load_func_annotation,
                             sample_fn=x,
@@ -129,9 +129,9 @@ def test_load(doi_sfaira_repr, dir_template: str = "../template_data"):
                 else:
                     datasets_f = [
                         DatasetFound(
-                            data_path=dir_template,
-                            meta_path=dir_template,
-                            cache_path=dir_template,
+                            data_path=test_data,
+                            meta_path=test_data,
+                            cache_path=test_data,
                             load_func=load_func,
                             load_func_annotation=load_func_annotation,
                             sample_fn=x,
@@ -152,9 +152,9 @@ def test_load(doi_sfaira_repr, dir_template: str = "../template_data"):
     # Test loading from cache:
     ds = DatasetGroupDirectoryOriented(
         file_base=file_path,
-        data_path=dir_template,
-        meta_path=dir_template,
-        cache_path=dir_template
+        data_path=test_data,
+        meta_path=test_data,
+        cache_path=test_data
     )
     ds.load(
         remove_gene_version=remove_gene_version,

--- a/sfaira/unit_tests/data_contribution/test_data_template.py
+++ b/sfaira/unit_tests/data_contribution/test_data_template.py
@@ -9,7 +9,7 @@ except ImportError:
     sfairae = None
 
 
-def test_load(dir_template: str = "../template_data", doi_sfaira_repr="d10_1016_j_cmet_2019_01_021"):
+def test_load(doi_sfaira_repr, dir_template: str = "../template_data"):
     """
     Unit test to assist with data set contribution.
 
@@ -30,8 +30,6 @@ def test_load(dir_template: str = "../template_data", doi_sfaira_repr="d10_1016_
     (Note that columns are separated by ",")
     You can also manually check maps here: https://www.ebi.ac.uk/ols/ontologies/cl
     5. Run this unit test for a last time to check the cell type maps.
-
-    :return:
     """
     remove_gene_version = True
     match_to_reference = None


### PR DESCRIPTION
Hi,

usage: `sfaira test-dataloader <path_to_sfaira> --doi <doi>`.
Example: `sfaira test-dataloader . --doi 10.1016.j.cmet.2019.01.021`

We need the path of sfaira to find the test and also since the test data is relative to the unit test python script.