### PR TITLE
set RTFD python version to 3.8

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,6 +10,6 @@ sphinx:
 formats: all
 
 python:
-  version: 3.9
+  version: 3.8
   install:
     - requirements: docs/requirements.txt


### PR DESCRIPTION
RTFD throws error for python version 3.9