### PR TITLE
restructured meta data streamlining code

### DIFF
--- a/sfaira/consts/adata_fields.py
+++ b/sfaira/consts/adata_fields.py
@@ -12,9 +12,7 @@ class AdataIds:
     annotated: str
     assay_sc: str
     author: str
-    cell_types_original: str
-    cellontology_class: str
-    cellontology_id: str
+    cell_type: str
     development_stage: str
     disease: str
     doi_journal: str
@@ -39,9 +37,14 @@ class AdataIds:
     tech_sample: str
     year: str
 
+    ontology_id_suffix: str
+    ontology_original_suffix: str
+
     load_raw: str
     mapped_features: str
     remove_gene_version: str
+
+    ontology_constrained: List[str]
 
     obs_keys: List[str]
     var_keys: List[str]
@@ -77,6 +80,9 @@ class AdataIdsSfaira(AdataIds):
     cell_line: str
 
     def __init__(self):
+        self.ontology_id_suffix = "_ontology_term_id"
+        self.ontology_original_suffix = "_original"
+
         self.annotated = "annotated"
         self.assay_sc = "assay_sc"
         self.assay_differentiation = "assay_differentiation"
@@ -84,9 +90,7 @@ class AdataIdsSfaira(AdataIds):
         self.author = "author"
         self.bio_sample = "bio_sample"
         self.cell_line = "cell_line"
-        self.cell_types_original = "cell_types_original"
-        self.cellontology_class = "cell_ontology_class"
-        self.cellontology_id = "cell_ontology_id"
+        self.cell_type = "cell_type"
         self.default_embedding = "default_embedding"
         self.disease = "disease"
         self.doi_journal = "doi_journal"
@@ -126,19 +130,25 @@ class AdataIdsSfaira(AdataIds):
         self.unknown_celltype_identifier = "UNKNOWN"
         self.not_a_cell_celltype_identifier = "NOT_A_CELL"
         self.unknown_metadata_identifier = "unknown"
-        self.unknown_metadata_ontology_id_identifier = "unknown"
 
         self.batch_keys = [self.bio_sample, self.individual, self.tech_sample]
 
+        self.ontology_constrained = [
+            "assay_sc",
+            "cell_line",
+            "cell_type",
+            "development_stage",
+            "disease",
+            #"ethnicity", TODO once ontologies work
+            "organ",
+        ]
         self.obs_keys = [
             "assay_sc",
             "assay_differentiation",
             "assay_type_differentiation",
             "bio_sample",
             "cell_line",
-            "cell_types_original",
-            "cellontology_class",
-            "cellontology_id",
+            "cell_type",
             "development_stage",
             "disease",
             "ethnicity",
@@ -181,12 +191,12 @@ class AdataIdsCellxgene(AdataIds):
     accepted_file_names: List[str]
 
     def __init__(self):
+        self.ontology_id_suffix = "_ontology_term_id"
+        self.ontology_original_suffix = "_original"
+
         self.assay_sc = "assay"
         self.author = None
-        self.cell_types_original = "free_annotation"  # TODO "free_annotation" not always given
-        # TODO: -> This will break streamlining though if self.cell_types_original is the same value as self.cellontology_class!!
-        self.cellontology_class = "cell_type"
-        self.cellontology_id = "cell_type_ontology_term_id"
+        self.cell_type = "cell_type"
         self.default_embedding = "default_embedding"
         self.doi_journal = "publication_doi"
         self.doi_preprint = "preprint_doi"
@@ -215,15 +225,21 @@ class AdataIdsCellxgene(AdataIds):
         self.not_a_cell_celltype_identifier = self.unknown_celltype_identifier
         self.unknown_metadata_identifier = "unknown"
         self.invalid_metadata_identifier = "na"
-        self.unknown_metadata_ontology_id_identifier = ""
 
         self.batch_keys = []
 
+        self.ontology_constrained = [
+            "assay_sc",
+            "cell_type",
+            "development_stage",
+            "disease",
+            "ethnicity",
+            "organ",
+        ]
+
         self.obs_keys = [
             "assay_sc",
-            "cell_types_original",
-            "cellontology_class",
-            "cellontology_id",
+            "cell_type",
             "development_stage",
             "disease",
             "ethnicity",

--- a/sfaira/consts/adata_fields.py
+++ b/sfaira/consts/adata_fields.py
@@ -37,8 +37,8 @@ class AdataIds:
     tech_sample: str
     year: str
 
-    ontology_id_suffix: str
-    ontology_original_suffix: str
+    onto_id_suffix: str
+    onto_original_suffix: str
 
     load_raw: str
     mapped_features: str
@@ -55,7 +55,7 @@ class AdataIds:
     classmap_target_key: str
     classmap_target_id_key: str
 
-    unknown_celltype_identifier: Union[str, None]
+    invalid_metadata_identifier: Union[str, None]
     not_a_cell_celltype_identifier: Union[str, None]
     unknown_metadata_identifier: Union[str, None]
 
@@ -80,8 +80,8 @@ class AdataIdsSfaira(AdataIds):
     cell_line: str
 
     def __init__(self):
-        self.ontology_id_suffix = "_ontology_term_id"
-        self.ontology_original_suffix = "_original"
+        self.onto_id_suffix = "_ontology_term_id"
+        self.onto_original_suffix = "_original"
 
         self.annotated = "annotated"
         self.assay_sc = "assay_sc"
@@ -127,7 +127,7 @@ class AdataIdsSfaira(AdataIds):
         self.classmap_target_key = "target"
         self.classmap_target_id_key = "target_id"
 
-        self.unknown_celltype_identifier = "UNKNOWN"
+        self.invalid_metadata_identifier = "na"
         self.not_a_cell_celltype_identifier = "NOT_A_CELL"
         self.unknown_metadata_identifier = "unknown"
 
@@ -139,7 +139,7 @@ class AdataIdsSfaira(AdataIds):
             "cell_type",
             "development_stage",
             "disease",
-            #"ethnicity", TODO once ontologies work
+            # "ethnicity", TODO once ontologies work
             "organ",
         ]
         self.obs_keys = [
@@ -191,8 +191,8 @@ class AdataIdsCellxgene(AdataIds):
     accepted_file_names: List[str]
 
     def __init__(self):
-        self.ontology_id_suffix = "_ontology_term_id"
-        self.ontology_original_suffix = "_original"
+        self.onto_id_suffix = "_ontology_term_id"
+        self.onto_original_suffix = "_original"
 
         self.assay_sc = "assay"
         self.author = None
@@ -221,10 +221,9 @@ class AdataIdsCellxgene(AdataIds):
         # selected element entries used for parsing:
         self.author_names = "names"
 
-        self.unknown_celltype_identifier = None
-        self.not_a_cell_celltype_identifier = self.unknown_celltype_identifier
-        self.unknown_metadata_identifier = "unknown"
         self.invalid_metadata_identifier = "na"
+        self.not_a_cell_celltype_identifier = "CL:0000003"
+        self.unknown_metadata_identifier = "unknown"
 
         self.batch_keys = []
 

--- a/sfaira/consts/ontologies.py
+++ b/sfaira/consts/ontologies.py
@@ -17,7 +17,7 @@ class OntologyContainerSfaira:
 
     _assay_sc: Union[None, OntologySinglecellLibraryConstruction]
     _cell_line: Union[None, OntologyCellosaurus]
-    _cellontology_class: Union[None, OntologyCl]
+    _cell_type: Union[None, OntologyCl]
     _development_stage: Union[None, Dict[str, Union[OntologyHsapdv, OntologyMmusdv]]]
     _organ: Union[None, OntologyUberon]
 
@@ -29,7 +29,7 @@ class OntologyContainerSfaira:
         self.assay_type_differentiation = OntologyList(terms=["guided", "unguided"])
         self.bio_sample = None
         self._cell_line = None
-        self._cellontology_class = None
+        self._cell_type = None
         self.cell_types_original = None
         self.collection_id = None
         self.default_embedding = None
@@ -63,7 +63,7 @@ class OntologyContainerSfaira:
         elif attr == "cell_line":
             self._cell_line = OntologyCellosaurus(**kwargs)
         elif attr == "cellontology_class":
-            self._cellontology_class = OntologyCl(branch=DEFAULT_CL, **kwargs)
+            self._cell_type = OntologyCl(branch=DEFAULT_CL, **kwargs)
         elif attr == "disease":
             self._disease = OntologyMondo(**kwargs)
         elif attr == "organ":
@@ -83,14 +83,14 @@ class OntologyContainerSfaira:
         return self._cell_line
 
     @property
-    def cellontology_class(self):
-        if self._cellontology_class is None:
-            self._cellontology_class = OntologyCl(branch=DEFAULT_CL)
-        return self._cellontology_class
+    def cell_type(self):
+        if self._cell_type is None:
+            self._cell_type = OntologyCl(branch=DEFAULT_CL)
+        return self._cell_type
 
-    @cellontology_class.setter
-    def cellontology_class(self, x: str):
-        self._cellontology_class = OntologyCl(branch=x)
+    @cell_type.setter
+    def cell_type(self, x: str):
+        self._cell_type = OntologyCl(branch=x)
 
     @property
     def development_stage(self):

--- a/sfaira/data/dataloaders/base/dataset.py
+++ b/sfaira/data/dataloaders/base/dataset.py
@@ -1107,6 +1107,17 @@ class DatasetBase(abc.ABC):
         """Standardised file name under which cell type conversion tables are saved."""
         return self.doi_cleaned_id + ".tsv"
 
+    def _write_ontology_class_map(self, fn, tab: pd.DataFrame):
+        """
+        Write class map to file.
+
+        Helper to allow direct interaction with written table instead of using table from instance.
+
+        :param fn: File name of csv to write class maps to.
+        :param tab: Class map table.
+        """
+        tab.to_csv(fn, index=False, sep="\t")
+
     def write_ontology_class_map(
             self,
             fn,
@@ -1133,11 +1144,13 @@ class DatasetBase(abc.ABC):
                 **kwargs
             )
             if not os.path.exists(fn) or not protected_writing:
-                tab.to_csv(fn, index=False, sep="\t")
+                self._write_ontology_class_map(fn=fn, tab=tab)
 
-    def read_class_map(self, fn) -> pd.DataFrame:
+    def _read_ontology_class_map(self, fn) -> pd.DataFrame:
         """
         Read class map.
+
+        Helper to allow direct interaction with resulting table instead of loading into instance.
 
         :param fn: File name of csv to load class maps from.
         :return:
@@ -1150,7 +1163,7 @@ class DatasetBase(abc.ABC):
             raise pandas.errors.ParserError(e)
         return tab
 
-    def load_ontology_class_map(self, fn):
+    def read_ontology_class_map(self, fn):
         """
         Load class maps of free text cell types to ontology classes.
 
@@ -1158,7 +1171,7 @@ class DatasetBase(abc.ABC):
         :return:
         """
         if os.path.exists(fn):
-            self.cell_type_map = self.read_class_map(fn=fn)
+            self.cell_type_map = self._read_ontology_class_map(fn=fn)
         else:
             if self.cell_type_obs_key is not None:
                 warnings.warn(f"file {fn} does not exist but cell_type_obs_key {self.cell_type_obs_key} is given")

--- a/sfaira/data/dataloaders/base/dataset.py
+++ b/sfaira/data/dataloaders/base/dataset.py
@@ -53,6 +53,7 @@ class DatasetBase(abc.ABC):
     _author: Union[None, str]
     _bio_sample: Union[None, str]
     _cell_line: Union[None, str]
+    _cell_type: Union[None, str]
     _default_embedding: Union[None, str]
     _development_stage: Union[None, str]
     _disease: Union[None, str]
@@ -76,27 +77,25 @@ class DatasetBase(abc.ABC):
     _bio_sample: Union[None, str]
     _year: Union[None, int]
 
-    _assay_sc_obs_key: Union[None, str]
-    _assay_differentiation_obs_key: Union[None, str]
-    _assay_type_differentiation_obs_key: Union[None, str]
-    _assay_cell_line_obs_key: Union[None, str]
-    _cellontology_class_obs_key: Union[None, str]
-    _cellontology_id_obs_key: Union[None, str]
-    _cell_types_original_obs_key: Union[None, str]
-    _development_stage_obs_key: Union[None, str]
-    _disease_obs_key: Union[None, str]
-    _ethnicity_obs_key: Union[None, str]
-    _individual: Union[None, str]
-    _organ_obs_key: Union[None, str]
-    _organism_obs_key: Union[None, str]
-    _bio_sample_obs_key: Union[None, str]
-    _sample_source_obs_key: Union[None, str]
-    _sex_obs_key: Union[None, str]
-    _state_exact_obs_key: Union[None, str]
-    _tech_sample_obs_key: Union[None, str]
+    assay_sc_obs_key: Union[None, str]
+    assay_differentiation_obs_key: Union[None, str]
+    assay_type_differentiation_obs_key: Union[None, str]
+    assay_cell_line_obs_key: Union[None, str]
+    bio_sample_obs_key: Union[None, str]
+    cell_type_obs_key: Union[None, str]
+    development_stage_obs_key: Union[None, str]
+    disease_obs_key: Union[None, str]
+    ethnicity_obs_key: Union[None, str]
+    individual_obs_key: Union[None, str]
+    organ_obs_key: Union[None, str]
+    organism_obs_key: Union[None, str]
+    sample_source_obs_key: Union[None, str]
+    sex_obs_key: Union[None, str]
+    state_exact_obs_key: Union[None, str]
+    tech_sample_obs_key: Union[None, str]
 
-    _gene_id_symbols_var_key: Union[None, str]
-    _gene_id_ensembl_var_key: Union[None, str]
+    gene_id_symbols_var_key: Union[None, str]
+    gene_id_ensembl_var_key: Union[None, str]
 
     _celltype_universe: Union[None, CelltypeUniverse]
     _ontology_class_map: Union[None, dict]
@@ -161,6 +160,7 @@ class DatasetBase(abc.ABC):
         self._assay_type_differentiation = None
         self._bio_sample = None
         self._cell_line = None
+        self._cell_type = None
         self._default_embedding = None
         self._development_stage = None
         self._disease = None
@@ -184,28 +184,25 @@ class DatasetBase(abc.ABC):
         self._title = None
         self._year = None
 
-        self._assay_sc_obs_key = None
-        self._assay_differentiation_obs_key = None
-        self._assay_type_differentiation_obs_key = None
-        self._bio_sample_obs_key = None
-        self._cell_line_obs_key = None
-        self._cellontology_class_obs_key = None
-        self._cellontology_id_obs_key = None
-        self._cell_types_original_obs_key = None
-        self._development_stage_obs_key = None
-        self._disease_obs_key = None
-        self._ethnicity_obs_key = None
+        self.assay_sc_obs_key = None
+        self.assay_differentiation_obs_key = None
+        self.assay_type_differentiation_obs_key = None
+        self.bio_sample_obs_key = None
+        self.cell_line_obs_key = None
+        self.cell_type_obs_key = None
+        self.development_stage_obs_key = None
+        self.disease_obs_key = None
+        self.ethnicity_obs_key = None
+        self.individual_obs_key = None
+        self.organ_obs_key = None
+        self.organism_obs_key = None
+        self.sample_source_obs_key = None
+        self.sex_obs_key = None
+        self.state_exact_obs_key = None
+        self.tech_sample_obs_key = None
 
-        self._individual_obs_key = None
-        self._organ_obs_key = None
-        self._organism_obs_key = None
-        self._sample_source_obs_key = None
-        self._sex_obs_key = None
-        self._state_exact_obs_key = None
-        self._tech_sample_obs_key = None
-
-        self._gene_id_symbols_var_key = None
-        self._gene_id_ensembl_var_key = None
+        self.gene_id_symbols_var_key = None
+        self.gene_id_ensembl_var_key = None
 
         self.class_maps = {"0": {}}
         self._unknown_celltype_identifiers = self._adata_ids.unknown_celltype_identifier
@@ -649,11 +646,27 @@ class DatasetBase(abc.ABC):
             clean_var: bool = True,
             clean_uns: bool = True,
             clean_obs_names: bool = True,
+            keep_orginal_obs: bool = False,
+            keep_symbol_obs: bool = True,
+            keep_id_obs: bool = True,
     ):
         """
         Streamline the adata instance to a defined output schema.
 
         Output format are saved in ADATA_FIELDS* classes.
+
+        Note on ontology-controlled meta data:
+        These are defined for a given format in `ADATA_FIELDS*.ontology_constrained`.
+        They may appear in three different formats:
+            - original (free text) annotation
+            - ontology symbol
+            - ontology ID
+        During streamlining, these ontology-controlled meta data are projected to all of these three different formats.
+        The initially annotated column may be any of these and is defined as "{attr}_obs_col".
+        The resulting three column per meta data item are named:
+            - ontology symbol: "{ADATA_FIELDS*.attr}"
+            - ontology ID: {ADATA_FIELDS*.attr}_{ADATA_FIELDS*.ontology_id_suffix}"
+            - original (free text) annotation: "{ADATA_FIELDS*.attr}_{ADATA_FIELDS*.ontology_original_suffix}"
 
         :param schema: Export format.
             - "sfaira"
@@ -661,7 +674,13 @@ class DatasetBase(abc.ABC):
         :param clean_obs: Whether to delete non-streamlined fields in .obs, .obsm and .obsp.
         :param clean_var: Whether to delete non-streamlined fields in .var, .varm and .varp.
         :param clean_uns: Whether to delete non-streamlined fields in .uns.
-        :param clean_obs_names: Whether to replace obs_names with a string comprised of dataset id and an increasing integer.
+        :param clean_obs_names: Whether to replace obs_names with a string comprised of dataset id and an increasing
+            integer.
+        :param keep_orginal_obs: For ontology-constrained .obs columns, whether to keep a column with original
+            annotation.
+        :param keep_symbol_obs: For ontology-constrained .obs columns, whether to keep a column with ontology symbol
+            annotation.
+        :param keep_id_obs: For ontology-constrained .obs columns, whether to keep a column with ontology ID annotation.
         :return:
         """
         self.__assert_loaded()
@@ -711,90 +730,6 @@ class DatasetBase(abc.ABC):
                 var_new[getattr(adata_target_ids, k)] = val
         # set var index
         var_new.index = var_new[adata_target_ids.gene_id_index].tolist()
-
-        # Prepare new .uns dict:
-        uns_new = {}
-        for k in adata_target_ids.uns_keys:
-            if hasattr(self, k) and getattr(self, k) is not None:
-                val = getattr(self, k)
-            elif hasattr(self, f"{k}_obs_key") and getattr(self, f"{k}_obs_key") is not None:
-                val = np.sort(np.unique(self.adata.obs[getattr(self, f"{k}_obs_key")].values)).tolist()
-            else:
-                val = None
-            while hasattr(val, '__len__') and not isinstance(val, str) and len(val) == 1:  # Unpack nested lists/tuples.
-                val = val[0]
-            uns_new[getattr(adata_target_ids, k)] = val
-
-        # Prepare new .obs dataframe
-        per_cell_labels = ["cell_types_original", "cellontology_class", "cellontology_id"]
-        obs_new = pd.DataFrame(index=self.adata.obs.index)
-        # Handle non-cell type labels:
-        for k in [x for x in adata_target_ids.obs_keys if x not in per_cell_labels]:
-            # Handle batch-annotation columns which can be provided as a combination of columns separated by an asterisk
-            if k in experiment_batch_labels and getattr(self, f"{k}_obs_key") is not None and \
-                    "*" in getattr(self, f"{k}_obs_key"):
-                old_cols = getattr(self, f"{k}_obs_key")
-                batch_cols = []
-                for batch_col in old_cols.split("*"):
-                    if batch_col in self.adata.obs_keys():
-                        batch_cols.append(batch_col)
-                    else:
-                        # This should not occur in single data set loaders (see warning below) but can occur in
-                        # streamlined data loaders if not all instances of the streamlined data sets have all columns
-                        # in .obs set.
-                        print(f"WARNING: attribute {batch_col} of data set {self.id} was not found in columns.")
-                # Build a combination label out of all columns used to describe this group.
-                val = [
-                    "_".join([str(xxx) for xxx in xx])
-                    for xx in zip(*[self.adata.obs[batch_col].values.tolist() for batch_col in batch_cols])
-                ]
-            else:
-                if hasattr(self, f"{k}_obs_key") and getattr(self, f"{k}_obs_key") is not None and \
-                        getattr(self, f"{k}_obs_key") in self.adata.obs.columns:
-                    # Last and-clause to check if this column is included in data sets. This may be violated if data
-                    # is obtained from a database which is not fully streamlined.
-                    old_col = getattr(self, f"{k}_obs_key")
-                    val = self.adata.obs[old_col].values.tolist()
-                else:
-                    val = getattr(self, k)
-                    if val is None:
-                        val = self._adata_ids.unknown_metadata_identifier
-                    # Unpack nested lists/tuples:
-                    while hasattr(val, '__len__') and not isinstance(val, str) and len(val) == 1:
-                        val = val[0]
-                    val = [val] * self.adata.n_obs
-            new_col = getattr(adata_target_ids, k)
-            # Check values for validity:
-            ontology = getattr(self.ontology_container_sfaira, k) \
-                if hasattr(self.ontology_container_sfaira, k) else None
-            if k == "development_stage":
-                ontology = ontology[self.organism]
-            if k == "ethnicity":
-                ontology = ontology[self.organism]
-            self._value_protection(attr=new_col, allowed=ontology, attempted=[
-                x for x in np.unique(val)
-                if x not in [
-                    self._adata_ids.unknown_metadata_identifier,
-                    self._adata_ids.unknown_metadata_ontology_id_identifier,
-                ]
-            ])
-            obs_new[new_col] = val
-            setattr(self, f"{k}_obs_key", new_col)
-        # Set cell types:
-        # Build auxilliary table with cell type information:
-        if self.cell_types_original_obs_key is not None:
-            obs_cl = self.project_celltypes_to_ontology(copy=True, adata_fields=self._adata_ids)
-        else:
-            obs_cl = pd.DataFrame({
-                self._adata_ids.cellontology_class: [self._adata_ids.unknown_metadata_identifier] * self.adata.n_obs,
-                self._adata_ids.cellontology_id: [self._adata_ids.unknown_metadata_identifier] * self.adata.n_obs,
-                self._adata_ids.cell_types_original: [self._adata_ids.unknown_metadata_identifier] * self.adata.n_obs,
-            }, index=self.adata.obs.index)
-        for k in [x for x in per_cell_labels if x in adata_target_ids.obs_keys]:
-            obs_new[getattr(adata_target_ids, k)] = obs_cl[getattr(self._adata_ids, k)]
-        del obs_cl
-
-        # Add new annotation to adata and delete old fields if requested
         if clean_var:
             if self.adata.varm is not None:
                 del self.adata.varm
@@ -813,6 +748,111 @@ class DatasetBase(abc.ABC):
                 pd.DataFrame(dict([(k, v) for k, v in self.adata.var.items() if k not in var_new.columns]))
             ], axis=1)
             self.adata.var.index = index_old
+
+        # Prepare new .uns dict:
+        uns_new = {}
+        for k in adata_target_ids.uns_keys:
+            if hasattr(self, k) and getattr(self, k) is not None:
+                val = getattr(self, k)
+            elif hasattr(self, f"{k}_obs_key") and getattr(self, f"{k}_obs_key") is not None:
+                val = np.sort(np.unique(self.adata.obs[getattr(self, f"{k}_obs_key")].values)).tolist()
+            else:
+                val = None
+            while hasattr(val, '__len__') and not isinstance(val, str) and len(val) == 1:  # Unpack nested lists/tuples.
+                val = val[0]
+            uns_new[getattr(adata_target_ids, k)] = val
+        if clean_uns:
+            self.adata.uns = uns_new
+        else:
+            self.adata.uns = {**self.adata.uns, **uns_new}
+
+        # Prepare new .obs dataframe
+        # Queried meta data may be:
+        # 1) in .obs
+        #   a) for an ontology-constrained meta data item
+        #       I) as free annotation with a term map to an ontology
+        #       II) as column with ontology symbols
+        #       III) as column with ontology IDs
+        #   b) for a non-ontology-constrained meta data item:
+        #       I) as free annotation
+        # 2) in .uns
+        #   b) as elements that are ontology symbols
+        #   c) as elements that are ontology IDs
+        # .obs annotation takes priority over .uns annotation if both are present.
+        # The output columns are:
+        # - for an ontology-constrained meta data item "attr":
+        #   *  symbols:         "attr"
+        #   *  IDs:             "attr" + self._adata_ids.ontology_id_suffix
+        #   *  original labels: "attr" + self._adata_ids.ontology_original_suffix
+        # - for a non-ontology-constrained meta data item "attr":
+        #   *  original labels: "attr" + self._adata_ids.ontology_original_suffix
+        obs_new = pd.DataFrame(index=self.adata.obs.index)
+        for k in [x for x in adata_target_ids.obs_keys]:
+            if k in experiment_batch_labels and getattr(self, f"{k}_obs_key") is not None and \
+                    "*" in getattr(self, f"{k}_obs_key"):
+                # Handle batch-annotation columns which can be provided as a combination of columns separated by an
+                # asterisk.
+                # The queried meta data are always:
+                # 1b-I) a combination of existing columns in .obs
+                old_cols = getattr(self, f"{k}_obs_key")
+                batch_cols = []
+                for batch_col in old_cols.split("*"):
+                    if batch_col in self.adata.obs_keys():
+                        batch_cols.append(batch_col)
+                    else:
+                        # This should not occur in single data set loaders (see warning below) but can occur in
+                        # streamlined data loaders if not all instances of the streamlined data sets have all columns
+                        # in .obs set.
+                        print(f"WARNING: attribute {batch_col} of data set {self.id} was not found in columns.")
+                # Build a combination label out of all columns used to describe this group.
+                val = [
+                    "_".join([str(xxx) for xxx in xx])
+                    for xx in zip(*[self.adata.obs[batch_col].values.tolist() for batch_col in batch_cols])
+                ]
+            else:
+                # Locate annotation.
+                if hasattr(self, f"{k}_obs_key") and getattr(self, f"{k}_obs_key") is not None and \
+                        getattr(self, f"{k}_obs_key") in self.adata.obs.columns:
+                    # Last and-clause to check if this column is included in data sets. This may be violated if data
+                    # is obtained from a database which is not fully streamlined.
+                    # Look for 1a-* and 1b-I
+                    val = self.adata.obs[getattr(self, f"{k}_obs_key")].values.tolist()
+                else:
+                    # Look for 2a, 2b
+                    val = getattr(self, k)
+                    if val is None:
+                        val = self._adata_ids.unknown_metadata_identifier
+                    # Unpack nested lists/tuples:
+                    while hasattr(val, '__len__') and not isinstance(val, str) and len(val) == 1:
+                        val = val[0]
+                    val = [val] * self.adata.n_obs
+            # Identify annotation: disambiguate 1a-I, 1a-II, 1a-III, 1b-I.
+            if k in self._adata_ids.ontology_constrained:
+                # 1a-*.
+                if isinstance(self.get_ontology(k=k), OntologyHierarchical) and np.all([
+                    self.get_ontology(k=k).is_a_node_name(x) or x == self._adata_ids.unknown_metadata_identifier
+                    for x in np.unique(val)
+                ]):  # 1a-II)
+                    new_col = getattr(adata_target_ids, k)
+                elif isinstance(self.get_ontology(k=k), OntologyHierarchical) and np.all([
+                    self.get_ontology(k=k).is_a_node_id(x) or x == self._adata_ids.unknown_metadata_identifier
+                    for x in np.unique(val)
+                ]):  # 1a-III)
+                    new_col = getattr(adata_target_ids, k) + self._adata_ids.ontology_id_suffix
+                else:  # 1a-I)
+                    new_col = getattr(adata_target_ids, k) + self._adata_ids.ontology_original_suffix
+            else:
+                # 1b-I.
+                new_col = getattr(adata_target_ids, k)
+            # Check values for validity:
+            self._value_protection(attr=new_col, allowed=self.get_ontology(k=k), attempted=[
+                x for x in np.unique(val)
+                if x not in [
+                    self._adata_ids.unknown_metadata_identifier,
+                ]
+            ])
+            obs_new[new_col] = val
+            # For ontology-constrained meta data, the remaining columns are added after .obs cleaning below.
         if clean_obs:
             if self.adata.obsm is not None:
                 del self.adata.obsm
@@ -829,12 +869,18 @@ class DatasetBase(abc.ABC):
                                    if k not in adata_target_ids.controlled_meta_keys]))
             ], axis=1)
             self.adata.obs.index = index_old
+        for k in [x for x in adata_target_ids.obs_keys if x in self._adata_ids.ontology_constrained]:
+            # Add remaining output columns for ontology-constrained meta data.
+            self.__impute_ontology_cols_obs(attr=k)
+            # Delete attribute-specific columns that are not desired.
+            if not keep_id_obs:
+                del self.adata.obs[getattr(self._adata_ids, k) + self._adata_ids.ontology_id_suffix]
+            if not keep_orginal_obs:
+                del self.adata.obs[getattr(self._adata_ids, k) + self._adata_ids.ontology_original_suffix]
+            if not keep_symbol_obs:
+                del self.adata.obs[getattr(self._adata_ids, k)]
         if clean_obs_names:
             self.adata.obs.index = [f"{self.id}_{i}" for i in range(1, self.adata.n_obs + 1)]
-        if clean_uns:
-            self.adata.uns = uns_new
-        else:
-            self.adata.uns = {**self.adata.uns, **uns_new}
 
         # Make sure that correct unknown_metadata_identifier is used in .uns, .obs and .var metadata
         unknown_old = self._adata_ids.unknown_metadata_identifier
@@ -868,27 +914,6 @@ class DatasetBase(abc.ABC):
                 self.adata.uns["organism_ontology_term_id"] = "NCBITaxon:9606"
             else:
                 raise ValueError(f"organism {self.organism} currently not supported by cellxgene schema")
-            # Add ontology IDs where necessary (note that human readable terms are also kept):
-            ontology_cols = ["organ", "assay_sc", "disease", "ethnicity", "development_stage"]
-            non_ontology_cols = ["sex"]
-            for k in ontology_cols:
-                # TODO enable ethinicity once the distinction between ontology for human and None for mouse works.
-                if getattr(adata_target_ids, k) in self.adata.obs.columns and k != "ethnicity":
-                    ontology = getattr(self.ontology_container_sfaira, k)
-                    # Disambiguate organism-dependent ontologies:
-                    if isinstance(ontology, dict):
-                        ontology = ontology[self.organism]
-                    self.__project_name_to_id_obs(
-                        ontology=ontology,
-                        key_in=getattr(adata_target_ids, k),
-                        key_out=getattr(adata_target_ids, k) + "_ontology_term_id",
-                        map_exceptions=[adata_target_ids.unknown_metadata_identifier],
-                        map_exceptions_value=adata_target_ids.unknown_metadata_ontology_id_identifier,
-                    )
-                else:
-                    self.adata.obs[getattr(adata_target_ids, k)] = adata_target_ids.unknown_metadata_identifier
-                    self.adata.obs[getattr(adata_target_ids, k) + "_ontology_term_id"] = \
-                        adata_target_ids.unknown_metadata_ontology_id_identifier
             # Correct unknown cell type entries:
             self.adata.obs[getattr(adata_target_ids, "cellontology_class")] = [
                 x if x not in [self._adata_ids.unknown_celltype_identifier,
@@ -901,9 +926,11 @@ class DatasetBase(abc.ABC):
                 else "CL:0000003"
                 for x in self.adata.obs[getattr(adata_target_ids, "cellontology_id")]]
             # Reorder data frame to put ontology columns first:
-            cellxgene_cols = [getattr(adata_target_ids, x) for x in ontology_cols] + \
-                             [getattr(adata_target_ids, x) for x in non_ontology_cols] + \
-                             [getattr(adata_target_ids, x) + "_ontology_term_id" for x in ontology_cols]
+            cellxgene_cols = [getattr(adata_target_ids, x) for x in adata_target_ids.ontology_constrained] + \
+                             [getattr(adata_target_ids, x) for x in adata_target_ids.obs_keys
+                              if x not in adata_target_ids.ontology_constrained] + \
+                             [getattr(adata_target_ids, x) + adata_target_ids.ontology_id_suffix
+                              for x in adata_target_ids.ontology_constrained]
             self.adata.obs = self.adata.obs[
                 cellxgene_cols + [x for x in self.adata.obs.columns if x not in cellxgene_cols]
             ]
@@ -1066,6 +1093,13 @@ class DatasetBase(abc.ABC):
     def doi_cleaned_id(self):
         return "_".join(self.id.split("_")[:-1])
 
+    def get_ontology(self, k) -> OntologyHierarchical:
+        x = getattr(self.ontology_container_sfaira, k) if hasattr(self.ontology_container_sfaira, k) else None
+        if isinstance(x, dict):
+            assert isinstance(self.organism, str)
+            x = x[self.organism]
+        return x
+
     @property
     def fn_ontology_class_map_tsv(self):
         """Standardised file name under which cell type conversion tables are saved."""
@@ -1085,9 +1119,9 @@ class DatasetBase(abc.ABC):
         :return:
         """
         if not self.annotated:
-            warnings.warn(f"attempted to write ontology classmaps for data set {self.id} without annotation")
+            warnings.warn(f"attempted to write ontology class maps for data set {self.id} without annotation")
         else:
-            labels_original = np.sort(np.unique(self.adata.obs[self.cell_types_original_obs_key].values))
+            labels_original = np.sort(np.unique(self.adata.obs[self.cell_type_obs_key].values))
             tab = self.celltypes_universe.prepare_celltype_map_tab(
                 source=labels_original,
                 match_only=False,
@@ -1132,35 +1166,34 @@ class DatasetBase(abc.ABC):
         :return:
         """
         if os.path.exists(fn):
-            self.cell_ontology_map = self._read_class_map(fn=fn)
+            self.cell_type_map = self._read_class_map(fn=fn)
         else:
-            if self.cell_types_original_obs_key is not None:
-                warnings.warn(f"file {fn} does not exist but cell_types_original_obs_key is given")
+            if self.cell_type_obs_key is not None:
+                warnings.warn(f"file {fn} does not exist but cell_type_obs_key {self.cell_type_obs_key} is given")
 
-    def project_celltypes_to_ontology(self, adata_fields: Union[AdataIds, None] = None, copy=False, update_fields=True):
+    def project_free_to_ontology(self, attr: str, copy: bool = False):
         """
         Project free text cell type names to ontology based on mapping table.
 
         ToDo: add ontology ID setting here.
+        ToDo: only for cell type right now, extend to other meta data in the future.
 
-        :param adata_fields: AdataIds instance that holds the column names to use for the annotation
         :param copy: If True, a dataframe with the celltype annotation is returned, otherwise self.adata.obs is updated
             inplace.
-        :param update_fields: If True, the celltype-related attributes of this Dataset instance are updated. Basically,
-            this should always be true, unless self.adata.obs is not updated by (or with the output of) this function.
-            This includes the following fields: self.cellontology_class_obs_key, self.cell_types_original_obs_key,
-            self.cellontology_id_obs_key
 
         :return:
         """
-        assert copy or update_fields, "when copy is set to False, update_fields cannot be False"
-
-        adata_fields = adata_fields if adata_fields is not None else self._adata_ids
+        ontology_map = attr + "_map"
+        assert hasattr(self, ontology_map), f"did not find ontology map for {attr} which was only defined by free " \
+                                            f"annotation"
+        ontology_map = getattr(self, ontology_map)
+        adata_fields = self._adata_ids
         results = {}
-        labels_original = self.adata.obs[self.cell_types_original_obs_key].values
-        if self.cell_ontology_map is not None:  # only if this was defined
+        col_original = attr + adata_fields.ontology_original_suffix
+        labels_original = self.adata.obs[col_original].values
+        if ontology_map is not None:  # only if this was defined
             labels_mapped = [
-                self.cell_ontology_map[x] if x in self.cell_ontology_map.keys()
+                ontology_map[x] if x in ontology_map.keys()
                 else x for x in labels_original
             ]
             # Convert unknown celltype placeholders (needs to be hardcoded here as placeholders are also hardcoded in
@@ -1177,7 +1210,7 @@ class DatasetBase(abc.ABC):
             # This aborts with a readable error if there was a target in the mapping file that doesnt match the ontology
             # This protection blocks progression in the unit test if not deactivated.
             self._value_protection(
-                attr="celltypes",
+                attr=attr,
                 allowed=self.ontology_celltypes,
                 attempted=[
                     x for x in list(set(labels_mapped))
@@ -1192,56 +1225,111 @@ class DatasetBase(abc.ABC):
             # TODO this could be changed in the future, this allows this function to be used both on cell type name
             #  mapping files with and without the ID in the third column.
             # This mapping blocks progression in the unit test if not deactivated.
-            ontology = getattr(self.ontology_container_sfaira, "cellontology_class")
-            ids_mapped = self.__project_name_to_id_obs(
-                ontology=ontology,
-                key_in=labels_mapped,
-                key_out=None,
+            results[adata_fields.cell_type] = labels_mapped
+            self.__project_ontology_ids_obs(
+                attr=adata_fields.cell_type,
                 map_exceptions=[
                     adata_fields.unknown_celltype_identifier,
                     adata_fields.not_a_cell_celltype_identifier
                 ],
+                in_id=False,
             )
-            results[adata_fields.cellontology_class] = labels_mapped
-            results[adata_fields.cellontology_id] = ids_mapped
-            if update_fields:
-                self.cellontology_id_obs_key = adata_fields.cellontology_id
         else:
-            results[adata_fields.cellontology_class] = labels_original
-            results[adata_fields.cellontology_id] = [adata_fields.unknown_metadata_identifier] * self.adata.n_obs
-        results[adata_fields.cell_types_original] = labels_original
-        if update_fields:
-            self.cellontology_class_obs_key = adata_fields.cellontology_class
-            self.cell_types_original_obs_key = adata_fields.cell_types_original
+            results[adata_fields.cell_type] = labels_original
+            results[adata_fields.cell_type + adata_fields.ontology_id_suffix] = \
+                [adata_fields.unknown_metadata_identifier] * self.adata.n_obs
+        results[adata_fields.cell_type + adata_fields.ontology_original_suffix] = labels_original
         if copy:
             return pd.DataFrame(results, index=self.adata.obs.index)
         else:
             for k, v in results.items():
                 self.adata.obs[k] = v
 
-    def __project_name_to_id_obs(
+    def __impute_ontology_cols_obs(
             self,
-            ontology: OntologyHierarchical,
-            key_in: Union[str, list],
-            key_out: Union[str, None],
-            map_exceptions: list,
+            attr: str,
+    ):
+        """
+        Add missing ontology defined columns (symbol, ID, original) for a given ontology.
+
+        1) If original column is non-empty and symbol and ID are empty:
+            orginal column is projected to ontology and both symbol and ID are inferred.
+            Note that in this case, a label map is required.
+        2) If ID column is non-empty or symbol is non-empty, an error is thrown.
+            a) If ID column is non-empty and symbol is empty, symbol is inferred.
+            b) If ID column is empty and symbol is non-empty, ID is inferred.
+            c) If ID column is non-empty and non-symbol is empty, symbol is inferred and over-written.
+                Note that this setting allows usage of data sets which were streamlined with a different ontology
+                version.
+            In all cases original is kept if it is set and is set to symbol otherwise.
+        3) If original, ID and symbol columns are empty, an error is thrown.
+        """
+        ontology = self.get_ontology(k=attr)
+        # Note that for symbol and ID, the columns may be filled but not streamlined according to the ontology,
+        # in that case the corresponding meta data is defined as absent.
+        # Check which level of meta data annotation is present.
+        # Symbols:
+        col_symbol = attr
+        symbol_col_present = col_symbol in self.adata.obs.columns
+        symbol_col_streamlined = np.all([
+            ontology.is_a_node_name(x) or x == self._adata_ids.unknown_metadata_identifier
+            for x in np.unique(self.adata.obs[col_symbol].values)]) if symbol_col_present else False
+        symbol_present = symbol_col_present and symbol_col_streamlined
+        # IDs:
+        col_id = attr + self._adata_ids.ontology_id_suffix
+        id_col_present = col_id in self.adata.obs.columns
+        id_col_streamlined = np.all([
+            ontology.is_a_node_id(x) or x == self._adata_ids.unknown_metadata_identifier
+            for x in np.unique(self.adata.obs[col_id].values)]) if id_col_present else False
+        id_present = id_col_present and id_col_streamlined
+        # Original annotation (free text):
+        col_original = attr + self._adata_ids.ontology_original_suffix
+        original_present = col_original in self.adata.obs.columns
+        if original_present and not symbol_present and not id_present:  # 1)
+            self.project_free_to_ontology(attr=attr, copy=False)
+        if symbol_present or id_present:  # 2)
+            if symbol_present and not id_present:  # 2a)
+                self.__project_ontology_ids_obs(attr=attr, in_id=False)
+            if not symbol_present and id_present:  # 2b)
+                self.__project_ontology_ids_obs(attr=attr, in_id=True)
+            if symbol_present and id_present:  # 2c)
+                self.__project_ontology_ids_obs(attr=attr, in_id=True)
+            if not original_present:
+                val = self.adata.obs[col_symbol]
+                self.adata.obs[col_original] = val
+        else:  # 3)
+            raise ValueError(f"could not impute obs columns for attribute {attr} because neither original annotation, "
+                             f"symbol nor ID was previously set.")
+
+    def __project_ontology_ids_obs(
+            self,
+            attr: str,
+            map_exceptions: Union[None, List[str]] = None,
             map_exceptions_value=None,
+            in_id: bool = False,
     ):
         """
         Project ontology names to IDs for a given ontology in .obs entries.
 
         :param ontology: ontology to use when converting to IDs
-        :param key_in: name of obs_column containing names to convert or python list containing these values
-        :param key_out: name of obs_column to write the IDs or None. If None, a python list with the new values will be returned
-        :param map_exceptions: list of values that should not be mapped
-        :param map_exceptions_value: placeholder target value for values excluded from mapping
+        :param attr: name of obs_column containing names to convert or python list containing these values
+        :param map_exceptions: list of values that should not be mapped.
+            Defaults to unknown meta data identifier defined in ID object if None.
+        :param map_exceptions_value: placeholder target value for values excluded from mapping.
+            Defaults to unknown meta data identifier defined in ID object if None.
+        :param in_id: Whether to output ontology symbol or ID.
         :return:
         """
-        assert ontology is not None, f"cannot project value for {key_in} because ontology is None"
-        assert isinstance(key_in, (str, list)), f"argument key_in needs to be of type str or list. Supplied" \
-                                                f"type: {type(key_in)}"
-        input_values = self.adata.obs[key_in].values if isinstance(key_in, str) else key_in
+        ontology = self.get_ontology(k=attr)
+        assert ontology is not None, f"cannot project value for {attr} because ontology is None"
+        assert isinstance(attr, (str, list)), f"argument key_in needs to be of type str or list. Supplied" \
+                                                f"type: {type(attr)}"
+        map_exceptions = map_exceptions if map_exceptions is not None else [self._adata_ids.unknown_metadata_identifier]
+        map_exceptions_value = map_exceptions_value if map_exceptions_value is not None else \
+            self._adata_ids.unknown_metadata_identifier
+        input_values = self.adata.obs[attr].values if isinstance(attr, str) else attr
         map_vals = dict([
+            (x, ontology.convert_to_name(x)) if in_id else
             (x, ontology.convert_to_id(x))
             for x in np.unique([
                 xx for xx in input_values
@@ -1252,10 +1340,8 @@ class DatasetBase(abc.ABC):
             map_vals[x] if x in map_vals.keys() else map_exceptions_value
             for x in input_values
         ]
-        if isinstance(key_out, str):
-            self.adata.obs[key_out] = output_values
-        else:
-            return output_values
+        key_out = attr if in_id else attr + self._adata_ids.ontology_id_suffix
+        self.adata.obs[key_out] = output_values
 
     @property
     def citation(self):
@@ -1333,40 +1419,14 @@ class DatasetBase(abc.ABC):
         meta = pandas.DataFrame(index=range(1))
         # Expand table by variably cell-wise or data set-wise meta data:
         for x in self._adata_ids.controlled_meta_fields:
-            if x in ["cell_types_original", "cellontology_class", "cellontology_id"]:
-                continue
-            elif x in ["bio_sample", "individual", "tech_sample"] and \
-                    hasattr(self, f"{x}_obs_key") and \
-                    getattr(self, f"{x}_obs_key") is not None and \
-                    "*" in getattr(self, f"{x}_obs_key"):
-                batch_cols = []
-                for batch_col in getattr(self, f"{x}_obs_key").split("*"):
-                    if batch_col in self.adata.obs_keys():
-                        batch_cols.append(batch_col)
-                    else:
-                        # This should not occur in single data set loaders (see warning below) but can occur in
-                        # streamlined data loaders if not all instances of the streamlined data sets have all columns
-                        # in .obs set.
-                        print(f"WARNING: attribute {x} of data set {self.id} was not found in column {batch_col}")
-                # Build a combination label out of all columns used to describe this group.
-                meta[getattr(self._adata_ids, x)] = (list(set([
-                    "_".join([str(xxx) for xxx in xx])
-                    for xx in zip(*[self.adata.obs[batch_col].values.tolist() for batch_col in batch_cols])
-                ])),)
-            elif hasattr(self, f"{x}_obs_key") and getattr(self, f"{x}_obs_key") is not None:
-                meta[getattr(self._adata_ids, x)] = (self.adata.obs[getattr(self, f"{x}_obs_key")].unique(),)
+            if hasattr(self, f"{x}_obs_key") and getattr(self, f"{x}_obs_key") is not None:
+                col = getattr(self._adata_ids, x)
+                meta[col] = (self.adata.obs[col].unique(), )
+                if x in self._adata_ids.ontology_constrained:
+                    col = getattr(self._adata_ids, x + self._adata_ids.ontology_id_suffix)
+                    meta[col] = (self.adata.obs[col].unique(), )
             else:
                 meta[getattr(self._adata_ids, x)] = getattr(self, x)
-        # Add cell types into table if available:
-        if self.cell_types_original_obs_key is not None:
-            mappings = self.project_celltypes_to_ontology(copy=True, update_fields=False)
-            meta[self._adata_ids.cellontology_class] = (mappings[self._adata_ids.cellontology_class].unique(),)
-            meta[self._adata_ids.cellontology_id] = (mappings[self._adata_ids.cellontology_id].unique(),)
-            meta[self._adata_ids.cell_types_original] = (mappings[self._adata_ids.cell_types_original].unique(),)
-        else:
-            meta[self._adata_ids.cellontology_class] = " "
-            meta[self._adata_ids.cellontology_id] = " "
-            meta[self._adata_ids.cell_types_original] = " "
         meta.to_csv(fn_meta)
 
     def set_dataset_id(
@@ -1404,7 +1464,7 @@ class DatasetBase(abc.ABC):
 
     @property
     def annotated(self) -> Union[bool, None]:
-        if self.cellontology_id_obs_key is not None or self.cell_types_original_obs_key is not None:
+        if self.cell_type_obs_key is not None:
             return True
         else:
             if self.meta is None:
@@ -1503,6 +1563,22 @@ class DatasetBase(abc.ABC):
     @cell_line.setter
     def cell_line(self, x: str):
         self._cell_line = x
+
+    @property
+    def cell_type(self) -> Union[None, str]:
+        if self._cell_type is not None:
+            return self._cell_type
+        else:
+            if self.meta is None:
+                self.load_meta(fn=None)
+            if self.meta is not None and self._adata_ids.cell_type in self.meta.columns:
+                return self.meta[self._adata_ids.cell_type]
+            else:
+                return None
+
+    @cell_type.setter
+    def cell_type(self, x: str):
+        self._cell_type = x
 
     @property
     def data_dir(self):
@@ -1809,150 +1885,6 @@ class DatasetBase(abc.ABC):
         self._primary_data = x
 
     @property
-    def assay_sc_obs_key(self) -> str:
-        return self._assay_sc_obs_key
-
-    @assay_sc_obs_key.setter
-    def assay_sc_obs_key(self, x: str):
-        self._assay_sc_obs_key = x
-
-    @property
-    def assay_differentiation_obs_key(self) -> str:
-        return self._assay_differentiation_obs_key
-
-    @assay_differentiation_obs_key.setter
-    def assay_differentiation_obs_key(self, x: str):
-        self._assay_differentiation_obs_key = x
-
-    @property
-    def assay_type_differentiation_obs_key(self) -> str:
-        return self._assay_type_differentiation_obs_key
-
-    @assay_type_differentiation_obs_key.setter
-    def assay_type_differentiation_obs_key(self, x: str):
-        self._assay_type_differentiation_obs_key = x
-
-    @property
-    def bio_sample_obs_key(self) -> str:
-        return self._bio_sample_obs_key
-
-    @bio_sample_obs_key.setter
-    def bio_sample_obs_key(self, x: str):
-        self._bio_sample_obs_key = x
-
-    @property
-    def cell_line_obs_key(self) -> str:
-        return self._cell_line_obs_key
-
-    @cell_line_obs_key.setter
-    def cell_line_obs_key(self, x: str):
-        self._cell_line_obs_key = x
-
-    @property
-    def cellontology_class_obs_key(self) -> str:
-        return self._cellontology_class_obs_key
-
-    @cellontology_class_obs_key.setter
-    def cellontology_class_obs_key(self, x: str):
-        self._cellontology_class_obs_key = x
-
-    @property
-    def cellontology_id_obs_key(self) -> str:
-        return self._cellontology_id_obs_key
-
-    @cellontology_id_obs_key.setter
-    def cellontology_id_obs_key(self, x: str):
-        self._cellontology_id_obs_key = x
-
-    @property
-    def cell_types_original_obs_key(self) -> str:
-        return self._cell_types_original_obs_key
-
-    @cell_types_original_obs_key.setter
-    def cell_types_original_obs_key(self, x: str):
-        self._cell_types_original_obs_key = x
-
-    @property
-    def development_stage_obs_key(self) -> str:
-        return self._development_stage_obs_key
-
-    @development_stage_obs_key.setter
-    def development_stage_obs_key(self, x: str):
-        self._development_stage_obs_key = x
-
-    @property
-    def disease_obs_key(self) -> str:
-        return self._disease_obs_key
-
-    @disease_obs_key.setter
-    def disease_obs_key(self, x: str):
-        self._disease_obs_key = x
-
-    @property
-    def ethnicity_obs_key(self) -> str:
-        return self._ethnicity_obs_key
-
-    @ethnicity_obs_key.setter
-    def ethnicity_obs_key(self, x: str):
-        self._ethnicity_obs_key = x
-
-    @property
-    def individual_obs_key(self) -> str:
-        return self._individual_obs_key
-
-    @individual_obs_key.setter
-    def individual_obs_key(self, x: str):
-        self._individual_obs_key = x
-
-    @property
-    def organ_obs_key(self) -> str:
-        return self._organ_obs_key
-
-    @organ_obs_key.setter
-    def organ_obs_key(self, x: str):
-        self._organ_obs_key = x
-
-    @property
-    def organism_obs_key(self) -> str:
-        return self._organism_obs_key
-
-    @organism_obs_key.setter
-    def organism_obs_key(self, x: str):
-        self._organism_obs_key = x
-
-    @property
-    def sample_source_obs_key(self) -> str:
-        return self._sample_source_obs_key
-
-    @sample_source_obs_key.setter
-    def sample_source_obs_key(self, x: str):
-        self._sample_source_obs_key = x
-
-    @property
-    def sex_obs_key(self) -> str:
-        return self._sex_obs_key
-
-    @sex_obs_key.setter
-    def sex_obs_key(self, x: str):
-        self._sex_obs_key = x
-
-    @property
-    def state_exact_obs_key(self) -> str:
-        return self._state_exact_obs_key
-
-    @state_exact_obs_key.setter
-    def state_exact_obs_key(self, x: str):
-        self._state_exact_obs_key = x
-
-    @property
-    def tech_sample_obs_key(self) -> str:
-        return self._tech_sample_obs_key
-
-    @tech_sample_obs_key.setter
-    def tech_sample_obs_key(self, x: str):
-        self._tech_sample_obs_key = x
-
-    @property
     def organ(self) -> Union[None, str]:
         if self._organ is not None:
             return self._organ
@@ -1984,6 +1916,8 @@ class DatasetBase(abc.ABC):
     @organism.setter
     def organism(self, x: str):
         x = self._value_protection(attr="organism", allowed=self.ontology_container_sfaira.organism, attempted=x)
+        # Update ontology container so that correct ontologies are queried:
+        self.ontology_container_sfaira.organism_cache = x
         self._organism = x
 
     @property
@@ -2061,21 +1995,6 @@ class DatasetBase(abc.ABC):
     def tech_sample(self, x: str):
         self._tech_sample = x
 
-    @property
-    def gene_id_ensembl_var_key(self) -> str:
-        return self._gene_id_ensembl_var_key
-
-    @gene_id_ensembl_var_key.setter
-    def gene_id_ensembl_var_key(self, x: str):
-        self._gene_id_ensembl_var_key = x
-
-    @property
-    def gene_id_symbols_var_key(self) -> str:
-        return self._gene_id_symbols_var_key
-
-    @gene_id_symbols_var_key.setter
-    def gene_id_symbols_var_key(self, x: str):
-        self._gene_id_symbols_var_key = x
 
     @property
     def year(self) -> Union[None, int]:
@@ -2096,7 +2015,7 @@ class DatasetBase(abc.ABC):
 
     @property
     def ontology_celltypes(self):
-        return self.ontology_container_sfaira.cellontology_class
+        return self.ontology_container_sfaira.cell_type
 
     @property
     def ontology_organ(self):
@@ -2112,11 +2031,11 @@ class DatasetBase(abc.ABC):
         return self._celltype_universe
 
     @property
-    def cell_ontology_map(self) -> dict:
+    def cell_type_map(self) -> dict:
         return self._ontology_class_map
 
-    @cell_ontology_map.setter
-    def cell_ontology_map(self, x: pd.DataFrame):
+    @cell_type_map.setter
+    def cell_type_map(self, x: pd.DataFrame):
         assert x.shape[1] in [2, 3], f"{x.shape} in {self.id}"
         assert x.columns[0] == self._adata_ids.classmap_source_key
         assert x.columns[1] == self._adata_ids.classmap_target_key
@@ -2191,8 +2110,6 @@ class DatasetBase(abc.ABC):
                 return self.meta[self._adata_ids.title]
             else:
                 return self.__crossref_query(k="title")
-
-    # Private methods:
 
     def _value_protection(
             self,

--- a/sfaira/data/dataloaders/base/dataset_group.py
+++ b/sfaira/data/dataloaders/base/dataset_group.py
@@ -544,7 +544,7 @@ class DatasetGroup:
             - "assay_sc" points to self.assay_sc_obs_key
             - "assay_type_differentiation" points to self.assay_type_differentiation_obs_key
             - "cell_line" points to self.cell_line
-            - "cellontology_class" points to self.cellontology_class_obs_key
+            - "cell_type" points to self.cell_type_obs_key
             - "developmental_stage" points to self.developmental_stage_obs_key
             - "ethnicity" points to self.ethnicity_obs_key
             - "organ" points to self.organ_obs_key
@@ -734,7 +734,7 @@ class DatasetGroupDirectoryOriented(DatasetGroup):
                     fn_map = os.path.join(self._cwd, file_module + ".tsv")
                     if os.path.exists(fn_map):
                         # Access reading and value protection mechanisms from first data set loaded in group.
-                        tab = list(self.datasets.values())[0]._read_class_map(fn=fn_map)
+                        tab = list(self.datasets.values())[0].read_class_map(fn=fn_map)
                         # Checks that the assigned ontology class names appear in the ontology.
                         list(self.datasets.values())[0]._value_protection(
                             attr="celltypes",
@@ -742,7 +742,7 @@ class DatasetGroupDirectoryOriented(DatasetGroup):
                             attempted=[
                                 x for x in np.unique(tab[self._adata_ids.classmap_target_key].values).tolist()
                                 if x not in [
-                                    self._adata_ids.unknown_celltype_identifier,
+                                    self._adata_ids.unknown_metadata_identifier,
                                     self._adata_ids.not_a_cell_celltype_identifier
                                 ]
                             ]
@@ -750,9 +750,9 @@ class DatasetGroupDirectoryOriented(DatasetGroup):
                         # Adds a third column with the corresponding ontology IDs into the file.
                         tab[self._adata_ids.classmap_target_id_key] = [
                             self.ontology_celltypes.convert_to_id(x)
-                            if x != self._adata_ids.unknown_celltype_identifier and
-                            x != self._adata_ids.not_a_cell_celltype_identifier
-                            else self._adata_ids.unknown_celltype_identifier
+                            if x != self._adata_ids.unknown_metadata_identifier and
+                               x != self._adata_ids.not_a_cell_celltype_identifier
+                            else self._adata_ids.unknown_metadata_identifier
                             for x in tab[self._adata_ids.classmap_target_key].values
                         ]
                         list(self.datasets.values())[0]._write_class_map(fn=fn_map, tab=tab)
@@ -1303,7 +1303,7 @@ class DatasetSuperGroup:
             - "assay_differentiation" points to self.assay_differentiation_obs_key
             - "assay_type_differentiation" points to self.assay_type_differentiation_obs_key
             - "cell_line" points to self.cell_line
-            - "cellontology_class" points to self.cellontology_class_obs_key
+            - "cell_type" points to self.cell_type_obs_key
             - "developmental_stage" points to self.developmental_stage_obs_key
             - "ethnicity" points to self.ethnicity_obs_key
             - "organ" points to self.organ_obs_key

--- a/sfaira/data/dataloaders/base/dataset_group.py
+++ b/sfaira/data/dataloaders/base/dataset_group.py
@@ -711,7 +711,7 @@ class DatasetGroupDirectoryOriented(DatasetGroup):
                                 )
                         # Load cell type maps:
                         for x in datasets_f:
-                            x.load_ontology_class_map(fn=os.path.join(self._cwd, file_module + ".tsv"))
+                            x.read_ontology_class_map(fn=os.path.join(self._cwd, file_module + ".tsv"))
                         datasets.extend(datasets_f)
 
         keys = [x.id for x in datasets]
@@ -734,13 +734,13 @@ class DatasetGroupDirectoryOriented(DatasetGroup):
                     fn_map = os.path.join(self._cwd, file_module + ".tsv")
                     if os.path.exists(fn_map):
                         # Access reading and value protection mechanisms from first data set loaded in group.
-                        tab = list(self.datasets.values())[0].read_class_map(fn=fn_map)
+                        tab = list(self.datasets.values())[0]._read_ontology_class_map(fn=fn_map)
                         # Checks that the assigned ontology class names appear in the ontology.
                         list(self.datasets.values())[0]._value_protection(
-                            attr="celltypes",
+                            attr="cell_type",
                             allowed=self.ontology_celltypes,
                             attempted=[
-                                x for x in np.unique(tab[self._adata_ids.classmap_target_key].values).tolist()
+                                x for x in np.unique(tab[self._adata_ids.classmap_target_key].values)
                                 if x not in [
                                     self._adata_ids.unknown_metadata_identifier,
                                     self._adata_ids.not_a_cell_celltype_identifier
@@ -750,12 +750,14 @@ class DatasetGroupDirectoryOriented(DatasetGroup):
                         # Adds a third column with the corresponding ontology IDs into the file.
                         tab[self._adata_ids.classmap_target_id_key] = [
                             self.ontology_celltypes.convert_to_id(x)
-                            if x != self._adata_ids.unknown_metadata_identifier and
-                               x != self._adata_ids.not_a_cell_celltype_identifier
+                            if (x != self._adata_ids.unknown_metadata_identifier and
+                                x != self._adata_ids.not_a_cell_celltype_identifier)
                             else self._adata_ids.unknown_metadata_identifier
                             for x in tab[self._adata_ids.classmap_target_key].values
                         ]
-                        list(self.datasets.values())[0]._write_class_map(fn=fn_map, tab=tab)
+                        # Get writing function from any (first) data set instance:
+                        k = list(self.datasets.keys())[0]
+                        self.datasets[k]._write_ontology_class_map(fn=fn_map, tab=tab)
 
 
 class DatasetSuperGroup:

--- a/sfaira/data/dataloaders/base/dataset_group.py
+++ b/sfaira/data/dataloaders/base/dataset_group.py
@@ -160,7 +160,10 @@ class DatasetGroup:
             clean_obs: bool = True,
             clean_var: bool = True,
             clean_uns: bool = True,
-            clean_obs_names: bool = True
+            clean_obs_names: bool = True,
+            keep_orginal_obs: bool = False,
+            keep_symbol_obs: bool = True,
+            keep_id_obs: bool = True,
     ):
         """
         Streamline the adata instance in each data set to output format.
@@ -173,6 +176,13 @@ class DatasetGroup:
         :param clean_var: Whether to delete non-streamlined fields in .var, .varm and .varp.
         :param clean_uns: Whether to delete non-streamlined fields in .uns.
         :param clean_obs_names: Whether to replace obs_names with a string comprised of dataset id and an increasing integer.
+        :param clean_obs_names: Whether to replace obs_names with a string comprised of dataset id and an increasing
+            integer.
+        :param keep_orginal_obs: For ontology-constrained .obs columns, whether to keep a column with original
+            annotation.
+        :param keep_symbol_obs: For ontology-constrained .obs columns, whether to keep a column with ontology symbol
+            annotation.
+        :param keep_id_obs: For ontology-constrained .obs columns, whether to keep a column with ontology ID annotation.
         :return:
         """
         for x in self.ids:
@@ -181,7 +191,10 @@ class DatasetGroup:
                 clean_obs=clean_obs,
                 clean_var=clean_var,
                 clean_uns=clean_uns,
-                clean_obs_names=clean_obs_names
+                clean_obs_names=clean_obs_names,
+                keep_orginal_obs=keep_orginal_obs,
+                keep_symbol_obs=keep_symbol_obs,
+                keep_id_obs=keep_id_obs,
             )
 
     def streamline_features(
@@ -312,7 +325,7 @@ class DatasetGroup:
         for k, v in self.datasets.items():
             if v.annotated:
                 labels_original = np.sort(np.unique(np.concatenate([
-                    v.adata.obs[v.cell_types_original_obs_key].values
+                    v.adata.obs[v.cell_type_original_obs_key].values
                 ])))
                 tab.append(v.celltypes_universe.prepare_celltype_map_tab(
                     source=labels_original,
@@ -472,7 +485,7 @@ class DatasetGroup:
         :return:
         """
         for _, v in self.datasets.items():
-            v.project_celltypes_to_ontology(adata_fields=adata_fields, copy=copy)
+            v.project_free_to_ontology(adata_fields=adata_fields, copy=copy)
 
     def subset(self, key, values: Union[list, tuple, np.ndarray]):
         """
@@ -1100,7 +1113,7 @@ class DatasetSuperGroup:
             self._adata_ids.author,
             self._adata_ids.cell_line,
             self._adata_ids.dataset,
-            self._adata_ids.cellontology_class,
+            self._adata_ids.cell_type,
             self._adata_ids.development_stage,
             self._adata_ids.normalization,
             self._adata_ids.organ,
@@ -1166,6 +1179,9 @@ class DatasetSuperGroup:
             clean_var: bool = True,
             clean_uns: bool = True,
             clean_obs_names: bool = True,
+            keep_orginal_obs: bool = False,
+            keep_symbol_obs: bool = True,
+            keep_id_obs: bool = True,
     ):
         """
         Streamline the adata instance in each group and each data set to output format.
@@ -1178,6 +1194,13 @@ class DatasetSuperGroup:
         :param clean_var: Whether to delete non-streamlined fields in .var, .varm and .varp.
         :param clean_uns: Whether to delete non-streamlined fields in .uns.
         :param clean_obs_names: Whether to replace obs_names with a string comprised of dataset id and an increasing integer.
+        :param clean_obs_names: Whether to replace obs_names with a string comprised of dataset id and an increasing
+            integer.
+        :param keep_orginal_obs: For ontology-constrained .obs columns, whether to keep a column with original
+            annotation.
+        :param keep_symbol_obs: For ontology-constrained .obs columns, whether to keep a column with ontology symbol
+            annotation.
+        :param keep_id_obs: For ontology-constrained .obs columns, whether to keep a column with ontology ID annotation.
         :return:
         """
         for x in self.dataset_groups:
@@ -1187,7 +1210,10 @@ class DatasetSuperGroup:
                     clean_obs=clean_obs,
                     clean_var=clean_var,
                     clean_uns=clean_uns,
-                    clean_obs_names=clean_obs_names
+                    clean_obs_names=clean_obs_names,
+                    keep_orginal_obs=keep_orginal_obs,
+                    keep_symbol_obs=keep_symbol_obs,
+                    keep_id_obs=keep_id_obs,
                 )
 
     def subset(self, key, values):
@@ -1297,7 +1323,7 @@ class DatasetSuperGroup:
         :return:
         """
         for _, v in self.dataset_groups:
-            v.project_celltypes_to_ontology(adata_fields=adata_fields, copy=copy)
+            v.project_free_to_ontology(adata_fields=adata_fields, copy=copy)
 
     def write_config(self, fn: Union[str, os.PathLike]):
         """

--- a/sfaira/data/dataloaders/databases/cellxgene/cellxgene_loader.py
+++ b/sfaira/data/dataloaders/databases/cellxgene/cellxgene_loader.py
@@ -58,9 +58,7 @@ class Dataset(DatasetBase):
         # The h5ad objects from cellxgene follow a particular structure and the following attributes are guaranteed to
         # be in place. Note that these point at the anndata instance and will only be available for evaluation after
         # download. See below for attributes that are lazily available
-        self.cellontology_class_obs_key = self._adata_ids_cellxgene.cellontology_class
-        self.cellontology_id_obs_key = self._adata_ids_cellxgene.cellontology_id
-        self.cellontology_original_obs_key = self._adata_ids_cellxgene.cell_types_original
+        self.cell_type_obs_key = self._adata_ids_cellxgene.cell_type
         self.development_stage_obs_key = self._adata_ids_cellxgene.development_stage
         self.disease_obs_key = self._adata_ids_cellxgene.disease
         self.ethnicity_obs_key = self._adata_ids_cellxgene.ethnicity
@@ -104,7 +102,7 @@ class Dataset(DatasetBase):
                         # TODO normal state label varies in disease annotation. This can be removed once streamlined.
                         v = "healthy"
                     elif k in ["assay_sc", "disease", "organ"] and \
-                            v["ontology_term_id"] != self._adata_ids_cellxgene.unknown_metadata_ontology_id_identifier:
+                            v["ontology_term_id"] != self._adata_ids_cellxgene.unknown_metadata_identifier:
                         v = v["ontology_term_id"]
                     else:
                         v = v["label"]
@@ -119,7 +117,7 @@ class Dataset(DatasetBase):
                         if v not in organism_map:
                             raise ValueError(f"value {v} not recognized")
                         v = organism_map[v]
-                if v != self._adata_ids_cellxgene.unknown_metadata_ontology_id_identifier and \
+                if v != self._adata_ids_cellxgene.unknown_metadata_identifier and \
                         v != self._adata_ids_cellxgene.invalid_metadata_identifier:
                     v_clean.append(v)
             try:

--- a/sfaira/data/dataloaders/databases/cellxgene/cellxgene_loader.py
+++ b/sfaira/data/dataloaders/databases/cellxgene/cellxgene_loader.py
@@ -68,7 +68,7 @@ class Dataset(DatasetBase):
 
         self.gene_id_symbols_var_key = self._adata_ids_cellxgene.gene_id_symbols
 
-        self._unknown_celltype_identifiers = self._adata_ids_cellxgene.unknown_celltype_identifier
+        self._unknown_celltype_identifiers = self._adata_ids_cellxgene.unknown_metadata_identifier
 
         self.collection_id = collection_id
         self.supplier = "cellxgene"

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_cell_2017_09_004/human_isletoflangerhans_2017_smartseq2_enge_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_cell_2017_09_004/human_isletoflangerhans_2017_smartseq2_enge_001.py
@@ -26,7 +26,7 @@ class Dataset(DatasetBase):
         self.organism = "human"
         self.year = 2017
         self.gene_id_symbols_var_key = "index"
-        self.cell_types_original_obs_key = "celltype"
+        self.cell_types_obs_key = "celltype"
         self.sample_source = "primary_tissue"
 
         self.set_dataset_id(idx=1)

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_cell_2018_02_001/mouse_x_2018_microwellseq_han_x.py
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_cell_2018_02_001/mouse_x_2018_microwellseq_han_x.py
@@ -311,7 +311,7 @@ class Dataset(DatasetBase):
         self.gene_id_symbols_var_key = "index"
 
         # Only adult and neonatal samples are annotated:
-        self.cell_types_original_obs_key = "Annotation" \
+        self.cell_types_obs_key = "Annotation" \
             if sample_dev_stage_dict[self.sample_fn] in ["adult", "neonatal"] and \
             self.sample_fn not in [
                 "NeontalBrain1_dge.txt.gz",

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_cell_2018_08_067/human_laminapropriaofmucosaofcolon_2019_10xsequencing_kinchen_001.yaml
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_cell_2018_08_067/human_laminapropriaofmucosaofcolon_2019_10xsequencing_kinchen_001.yaml
@@ -52,7 +52,7 @@ dataset_or_observation_wise:
     tech_sample:
     tech_sample_obs_key:
 observation_wise:
-    cell_types_original_obs_key: "Cluster"
+    cell_type_obs_key: "Cluster"
 feature_wise:
     gene_id_ensembl_var_key:
     gene_id_symbols_var_key: "index"

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_cell_2019_06_029/human_colonicepithelium_2019_10xsequencing_smilie_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_cell_2019_06_029/human_colonicepithelium_2019_10xsequencing_smilie_001.py
@@ -26,7 +26,7 @@ class Dataset(DatasetBase):
 
         self.gene_id_symbols_var_key = "index"
 
-        self.cell_types_original_obs_key = "CellType"
+        self.cell_type_obs_key = "CellType"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_cell_2019_08_008/human_ileum_2019_10xsequencing_martin_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_cell_2019_08_008/human_ileum_2019_10xsequencing_martin_001.py
@@ -26,7 +26,7 @@ class Dataset(DatasetBase):
         self.gene_id_symbols_var_key = "index"
         self.gene_id_ensembl_var_key = "gene_ids"
 
-        self.cell_types_original_obs_key = "CellType"
+        self.cell_type_obs_key = "CellType"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_celrep_2018_11_086/human_prostategland_2018_10xsequencing_henry_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_celrep_2018_11_086/human_prostategland_2018_10xsequencing_henry_001.py
@@ -31,7 +31,7 @@ class Dataset(DatasetBase):
 
         self.gene_id_symbols_var_key = "index"
 
-        self.cell_types_original_obs_key = "CellType"
+        self.cell_type_obs_key = "CellType"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_cels_2016_08_011/human_pancreas_2016_indrop_baron_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_cels_2016_08_011/human_pancreas_2016_indrop_baron_001.py
@@ -25,7 +25,7 @@ class Dataset(DatasetBase):
         self.year = 2016
 
         self.gene_id_symbols_var_key = "index"
-        self.cell_types_original_obs_key = "CellType"
+        self.cell_type_obs_key = "CellType"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_cmet_2016_08_020/human_pancreas_2016_smartseq2_segerstolpe_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_cmet_2016_08_020/human_pancreas_2016_smartseq2_segerstolpe_001.py
@@ -26,7 +26,7 @@ class Dataset(DatasetBase):
 
         self.gene_id_symbols_var_key = "index"
 
-        self.cell_types_original_obs_key = "Characteristics[cell type]"
+        self.cell_type_obs_key = "Characteristics[cell type]"
         self.state_exact_obs_key = "Characteristics[disease]"
 
         self.set_dataset_id(idx=1)

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_cmet_2019_01_021/mouse_pancreas_2019_10xsequencing_thompson_x.py
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_cmet_2019_01_021/mouse_pancreas_2019_10xsequencing_thompson_x.py
@@ -40,7 +40,7 @@ class Dataset(DatasetBase):
 
         self.gene_id_symbols_var_key = "names"
         self.gene_id_ensembl_var_key = "ensembl"
-        self.cell_types_original_obs_key = "celltypes"
+        self.cell_type_obs_key = "celltypes"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_devcel_2020_01_033/human_lung_2020_10xsequencing_miller_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_devcel_2020_01_033/human_lung_2020_10xsequencing_miller_001.py
@@ -25,7 +25,7 @@ class Dataset(DatasetBase):
         self.year = 2020
 
         self.gene_id_symbols_var_key = "index"
-        self.cell_types_original_obs_key = "Cell_type"
+        self.cell_type_obs_key = "Cell_type"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_neuron_2019_06_011/human_brain_2019_dropseq_polioudakis_001.yaml
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_neuron_2019_06_011/human_brain_2019_dropseq_polioudakis_001.yaml
@@ -43,7 +43,7 @@ dataset_or_observation_wise:
     tech_sample:
     tech_sample_obs_key: "Index"
 observation_wise:
-    cell_types_original_obs_key: "celltype"
+    cell_type_obs_key: "celltype"
 feature_wise:
     gene_id_ensembl_var_key:
     gene_id_symbols_var_key: "index"

--- a/sfaira/data/dataloaders/loaders/d10_1038_nmeth_4407/human_brain_2017_droncseq_habib_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1038_nmeth_4407/human_brain_2017_droncseq_habib_001.py
@@ -24,7 +24,7 @@ class Dataset(DatasetBase):
         self.year = 2017
 
         self.gene_id_symbols_var_key = "index"
-        self.cell_types_original_obs_key = "CellType"
+        self.cell_type_obs_key = "CellType"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41422_018_0099_2/human_testis_2018_10xsequencing_guo_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41422_018_0099_2/human_testis_2018_10xsequencing_guo_001.py
@@ -24,7 +24,7 @@ class Dataset(DatasetBase):
         self.year = 2018
 
         self.gene_id_symbols_var_key = "index"
-        self.cell_types_original_obs_key = "CellType"
+        self.cell_type_obs_key = "CellType"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41467_018_06318_7/human_caudatelobeofliver_2018_10xsequencing_macparland_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41467_018_06318_7/human_caudatelobeofliver_2018_10xsequencing_macparland_001.py
@@ -23,7 +23,7 @@ class Dataset(DatasetBase):
         self.year = 2018
 
         self.gene_id_symbols_var_key = "index"
-        self.cell_types_original_obs_key = "celltype"
+        self.cell_type_obs_key = "celltype"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41467_019_10861_2/human_kidney_2019_droncseq_lake_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41467_019_10861_2/human_kidney_2019_droncseq_lake_001.py
@@ -25,7 +25,7 @@ class Dataset(DatasetBase):
         self.year = 2019
 
         self.gene_id_symbols_var_key = "index"
-        self.cell_types_original_obs_key = "celltype"
+        self.cell_type_obs_key = "celltype"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41467_019_12464_3/human_x_2019_10xsequencing_szabo_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41467_019_12464_3/human_x_2019_10xsequencing_szabo_001.py
@@ -72,7 +72,7 @@ class Dataset(DatasetBase):
         self.gene_id_symbols_var_key = "Gene"
         self.gene_id_ensembl_var_key = "Accession"
 
-        self.cell_types_original_obs_key = "cell_ontology_class"
+        self.cell_type_obs_key = "cell_ontology_class"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41467_019_12780_8/human_retina_2019_10xsequencing_menon_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41467_019_12780_8/human_retina_2019_10xsequencing_menon_001.py
@@ -22,7 +22,7 @@ class Dataset(DatasetBase):
         self.year = 2019
 
         self.gene_id_symbols_var_key = "index"
-        self.cell_types_original_obs_key = "CellType"
+        self.cell_type_obs_key = "CellType"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41586_018_0698_6/human_placenta_2018_x_ventotormo_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41586_018_0698_6/human_placenta_2018_x_ventotormo_001.py
@@ -31,7 +31,7 @@ class Dataset(DatasetBase):
 
         self.gene_id_symbols_var_key = "names"
         self.gene_id_ensembl_var_key = "ensembl"
-        self.cell_types_original_obs_key = "annotation"
+        self.cell_type_obs_key = "annotation"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41586_019_1373_2/human_liver_2019_celseq2_aizarani_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41586_019_1373_2/human_liver_2019_celseq2_aizarani_001.py
@@ -23,7 +23,7 @@ class Dataset(DatasetBase):
         self.year = 2019
 
         self.gene_id_symbols_var_key = "index"
-        self.cell_types_original_obs_key = "CellType"
+        self.cell_type_obs_key = "CellType"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41586_019_1631_3/human_liver_2019_10xsequencing_ramachandran_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41586_019_1631_3/human_liver_2019_10xsequencing_ramachandran_001.py
@@ -25,7 +25,7 @@ class Dataset(DatasetBase):
 
         self.gene_id_symbols_var_key = "index"
 
-        self.cell_types_original_obs_key = "annotation_lineage"
+        self.cell_type_obs_key = "annotation_lineage"
         self.state_exact_obs_key = "condition"
 
         self.set_dataset_id(idx=1)

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41586_019_1652_y/human_liver_2019_10xsequencing_popescu_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41586_019_1652_y/human_liver_2019_10xsequencing_popescu_001.py
@@ -23,7 +23,7 @@ class Dataset(DatasetBase):
         self.year = 2019
 
         self.gene_id_symbols_var_key = "index"
-        self.cell_types_original_obs_key = "cell.labels"
+        self.cell_type_obs_key = "cell.labels"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41586_019_1654_9/human_brain_2019_10x3v2sequencing_kanton_001.yaml
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41586_019_1654_9/human_brain_2019_10x3v2sequencing_kanton_001.yaml
@@ -45,7 +45,7 @@ dataset_or_observation_wise:
     tech_sample:
     tech_sample_obs_key:
 observation_wise:
-    cell_types_original_obs_key:
+    cell_type_obs_key:
 feature_wise:
     gene_id_ensembl_var_key: "ensembl"
     gene_id_symbols_var_key: "index"

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_2157_4/human_x_2020_microwellseq_han_x.py
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_2157_4/human_x_2020_microwellseq_han_x.py
@@ -29,7 +29,7 @@ class Dataset(DatasetBase):
         self.sample_source = "primary_tissue"
 
         self.bio_sample_obs_key = "sample"
-        self.cell_types_original_obs_key = "celltype_specific"
+        self.cell_type_obs_key = "celltype_specific"
         self.development_stage_obs_key = "dev_stage"
         self.organ_obs_key = "organ"
         self.sex_obs_key = "sex"

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_2922_4/human_lung_2020_x_travaglini_001.yaml
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_2922_4/human_lung_2020_x_travaglini_001.yaml
@@ -54,7 +54,7 @@ dataset_or_observation_wise:
         droplet_normal_lung_blood_scanpy.20200205.RC4.h5ad: "channel"
         facs_normal_lung_blood_scanpy.20200205.RC4.h5ad: "plate.barcode"
 observation_wise:
-    cell_types_original_obs_key: "free_annotation"
+    cell_type_obs_key: "free_annotation"
 feature_wise:
     gene_id_ensembl_var_key:
     gene_id_symbols_var_key: "index"

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41590_020_0602_z/human_colon_2020_10xsequencing_james_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41590_020_0602_z/human_colon_2020_10xsequencing_james_001.py
@@ -27,7 +27,7 @@ class Dataset(DatasetBase):
 
         self.gene_id_symbols_var_key = "index"
         self.gene_id_ensembl_var_key = "gene_ids"
-        self.cell_types_original_obs_key = "cell_type"
+        self.cell_type_obs_key = "cell_type"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41591_019_0468_5/human_lung_2019_dropseq_braga_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41591_019_0468_5/human_lung_2019_dropseq_braga_001.py
@@ -24,7 +24,7 @@ class Dataset(DatasetBase):
         self.year = 2019
 
         self.gene_id_symbols_var_key = "index"
-        self.cell_types_original_obs_key = "celltype"
+        self.cell_type_obs_key = "celltype"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41591_019_0468_5/human_x_2019_10xsequencing_braga_x.py
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41591_019_0468_5/human_x_2019_10xsequencing_braga_x.py
@@ -28,7 +28,7 @@ class Dataset(DatasetBase):
         self.year = 2019
 
         self.gene_id_symbols_var_key = "index"
-        self.cell_types_original_obs_key = "CellType"
+        self.cell_type_obs_key = "CellType"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41593_019_0393_4/mouse_x_2019_10xsequencing_hove_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41593_019_0393_4/mouse_x_2019_10xsequencing_hove_001.py
@@ -27,7 +27,7 @@ class Dataset(DatasetBase):
         self.year = 2019
 
         self.bio_sample_obs_key = "sample"
-        self.cell_types_original_obs_key = "cluster"
+        self.cell_type_obs_key = "cluster"
         self.organ_obs_key = "organ"
 
         self.gene_id_ensembl_var_key = "ensembl"

--- a/sfaira/data/dataloaders/loaders/d10_1073_pnas_1914143116/human_retina_2019_10xsequencing_voigt_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1073_pnas_1914143116/human_retina_2019_10xsequencing_voigt_001.py
@@ -23,7 +23,7 @@ class Dataset(DatasetBase):
         self.year = 2019
 
         self.gene_id_symbols_var_key = "index"
-        self.cell_types_original_obs_key = "CellType"
+        self.cell_type_obs_key = "CellType"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_1084_jem_20191130/human_x_2019_10xsequencing_wang_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1084_jem_20191130/human_x_2019_10xsequencing_wang_001.py
@@ -32,7 +32,7 @@ class Dataset(DatasetBase):
         self.year = 2019
 
         self.gene_id_symbols_var_key = "index"
-        self.cell_types_original_obs_key = "CellType"
+        self.cell_type_obs_key = "CellType"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_1101_2020_03_13_991455/human_lung_2020_10xsequencing_lukassen_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1101_2020_03_13_991455/human_lung_2020_10xsequencing_lukassen_001.py
@@ -30,7 +30,7 @@ class Dataset(DatasetBase):
         self.year = 2020
 
         self.gene_id_symbols_var_key = "index"
-        self.cell_types_original_obs_key = "CellType"
+        self.cell_type_obs_key = "CellType"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_1101_2020_10_12_335331/human_blood_2020_10x_hao_001.yaml
+++ b/sfaira/data/dataloaders/loaders/d10_1101_2020_10_12_335331/human_blood_2020_10x_hao_001.yaml
@@ -44,7 +44,7 @@ dataset_or_observation_wise:
     tech_sample:
     tech_sample_obs_key: 'Batch'
 observation_wise:
-    cell_types_original_obs_key: "celltype.l3"
+    cell_type_obs_key: "celltype.l3"
 feature_wise:
     gene_id_ensembl_var_key:
     gene_id_symbols_var_key: "names"

--- a/sfaira/data/dataloaders/loaders/d10_1101_661728/mouse_x_2019_x_pisco_x.py
+++ b/sfaira/data/dataloaders/loaders/d10_1101_661728/mouse_x_2019_x_pisco_x.py
@@ -76,7 +76,7 @@ class Dataset(DatasetBase):
                                  f"{self.sample_fn}"
         self.download_url_meta = None
 
-        self.cell_types_original_obs_key = "cell_ontology_class"
+        self.cell_type_obs_key = "cell_ontology_class"
         self.development_stage_obs_key = "development_stage"
         self.sex_obs_key = "sex"
         # ToDo: further anatomical information for subtissue in "subtissue"?

--- a/sfaira/data/dataloaders/loaders/d10_1101_753806/human_lungparenchyma_2020_10xsequencing_habermann_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1101_753806/human_lungparenchyma_2020_10xsequencing_habermann_001.py
@@ -42,7 +42,7 @@ class Dataset(DatasetBase):
 
         self.gene_id_symbols_var_key = "index"
 
-        self.cell_types_original_obs_key = "celltype"
+        self.cell_type_obs_key = "celltype"
         self.state_exact_obs_key = "Diagnosis"
 
         self.set_dataset_id(idx=1)

--- a/sfaira/data/dataloaders/loaders/d10_1126_science_aat5031/human_kidney_2019_10xsequencing_stewart_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1126_science_aat5031/human_kidney_2019_10xsequencing_stewart_001.py
@@ -32,7 +32,7 @@ class Dataset(DatasetBase):
 
         self.gene_id_symbols_var_key = "index"
         self.gene_id_ensembl_var_key = "ID"
-        self.cell_types_original_obs_key = "celltype"
+        self.cell_type_obs_key = "celltype"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_1126_science_aay3224/human_thymus_2020_10xsequencing_park_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1126_science_aay3224/human_thymus_2020_10xsequencing_park_001.py
@@ -33,7 +33,7 @@ class Dataset(DatasetBase):
         self.year = 2020
 
         self.gene_id_symbols_var_key = "index"
-        self.cell_types_original_obs_key = "Anno_level_fig1"
+        self.cell_type_obs_key = "Anno_level_fig1"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_1126_science_aba7721/human_x_2020_scirnaseq_cao_001.yaml
+++ b/sfaira/data/dataloaders/loaders/d10_1126_science_aba7721/human_x_2020_scirnaseq_cao_001.yaml
@@ -44,7 +44,7 @@ dataset_or_observation_wise:
     tech_sample:
     tech_sample_obs_key: "Experiment_batch"
 observation_wise:
-    cell_types_original_obs_key: "Main_cluster_name"
+    cell_type_obs_key: "Main_cluster_name"
 feature_wise:
     gene_id_ensembl_var_key: "gene_id"
     gene_id_symbols_var_key: "gene_short_name"

--- a/sfaira/data/dataloaders/loaders/d10_1186_s13059_019_1906_x/human_x_2019_10xsequencing_madissoon_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1186_s13059_019_1906_x/human_x_2019_10xsequencing_madissoon_001.py
@@ -45,7 +45,7 @@ class Dataset(DatasetBase):
         self.sample_source = "primary_tissue"
 
         self.gene_id_symbols_var_key = "index"
-        self.cell_types_original_obs_key = "Celltypes"
+        self.cell_type_obs_key = "Celltypes"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/dataloaders/loaders/d10_15252_embj_2018100811/human_retina_2019_10xsequencing_lukowski_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_15252_embj_2018100811/human_retina_2019_10xsequencing_lukowski_001.py
@@ -26,7 +26,7 @@ class Dataset(DatasetBase):
 
         self.gene_id_symbols_var_key = "index"
         self.gene_id_ensembl_var_key = "gene_ids"
-        self.cell_types_original_obs_key = "CellType"
+        self.cell_type_obs_key = "CellType"
 
         self.set_dataset_id(idx=1)
 

--- a/sfaira/data/store/multi_store.py
+++ b/sfaira/data/store/multi_store.py
@@ -158,7 +158,7 @@ class DistributedStoreMultipleFeatureSpaceBase(DistributedStoreBase):
             - "assay_sc" points to self.assay_sc_obs_key
             - "assay_type_differentiation" points to self.assay_type_differentiation_obs_key
             - "cell_line" points to self.cell_line
-            - "cellontology_class" points to self.cellontology_class_obs_key
+            - "cell_type" points to self.cell_type_obs_key
             - "developmental_stage" points to self.developmental_stage_obs_key
             - "ethnicity" points to self.ethnicity_obs_key
             - "organ" points to self.organ_obs_key

--- a/sfaira/data/store/single_store.py
+++ b/sfaira/data/store/single_store.py
@@ -239,7 +239,7 @@ class DistributedStoreSingleFeatureSpace(DistributedStoreBase):
             - "assay_sc" points to self.assay_sc_obs_key
             - "assay_type_differentiation" points to self.assay_type_differentiation_obs_key
             - "cell_line" points to self.cell_line
-            - "cellontology_class" points to self.cellontology_class_obs_key
+            - "cell_type" points to self.cell_type_obs_key
             - "developmental_stage" points to self.developmental_stage_obs_key
             - "ethnicity" points to self.ethnicity_obs_key
             - "organ" points to self.organ_obs_key
@@ -333,7 +333,7 @@ class DistributedStoreSingleFeatureSpace(DistributedStoreBase):
             - "assay_sc" points to self.assay_sc_obs_key
             - "assay_type_differentiation" points to self.assay_type_differentiation_obs_key
             - "cell_line" points to self.cell_line
-            - "cellontology_class" points to self.cellontology_class_obs_key
+            - "cell_type" points to self.cell_type_obs_key
             - "developmental_stage" points to self.developmental_stage_obs_key
             - "ethnicity" points to self.ethnicity_obs_key
             - "organ" points to self.organ_obs_key
@@ -538,7 +538,7 @@ class DistributedStoreSingleFeatureSpace(DistributedStoreBase):
         Uses self.dataset_weights if this are given to sample data sets with different frequencies.
         Can additionally also balance across one meta data annotation within each data set.
 
-        Assume you have a data set with two classes (A=80, B=20 cells) in a column named "cellontology_class".
+        Assume you have a data set with two classes (A=80, B=20 cells) in a column named "cell_type".
         The single batch for this data set produced by this generator in each epoch contains N cells.
         If balance_obs is False, these N cells are the result of a draw without replacement from all 100 cells in this
         dataset in which each cell receives the same weight / success probability of 1.0.

--- a/sfaira/data/utils.py
+++ b/sfaira/data/utils.py
@@ -52,7 +52,7 @@ def map_celltype_to_ontology(
         queries = [queries]
     oc = OntologyContainerSfaira()
     cu = CelltypeUniverse(
-        cl=oc.cellontology_class,
+        cl=oc.cell_type,
         uberon=oc.organ,
         organism=organism,
         **kwargs

--- a/sfaira/data/utils_scripts/create_target_universes.py
+++ b/sfaira/data/utils_scripts/create_target_universes.py
@@ -36,7 +36,7 @@ for f in os.listdir(config_path):
                         celltypes_found = celltypes_found.union(
                             set(store.adatas[k].obs[col_name_annot].values[idx].tolist())
                         )
-            celltypes_found = sorted(list(celltypes_found - {store._adata_ids_sfaira.unknown_celltype_identifier,
+            celltypes_found = sorted(list(celltypes_found - {store._adata_ids_sfaira.unknown_metadata_identifier,
                                                              store._adata_ids_sfaira.not_a_cell_celltype_identifier}))
             if len(celltypes_found) == 0:
                 print(f"WARNING: No cells found for {organism} {organ}, skipping.")

--- a/sfaira/data/utils_scripts/streamline_selected.py
+++ b/sfaira/data/utils_scripts/streamline_selected.py
@@ -35,7 +35,10 @@ for doi in dois.split(","):
             clean_obs=False,
             clean_var=True,
             clean_uns=True,
-            clean_obs_names=False
+            clean_obs_names=False,
+            keep_orginal_obs=False,
+            keep_symbol_obs=True,
+            keep_id_obs=True,
         )
         ds.collapse_counts()
     assert len(ds.dataset_groups) == 1, len(ds.dataset_groups)

--- a/sfaira/estimators/keras.py
+++ b/sfaira/estimators/keras.py
@@ -741,13 +741,13 @@ class EstimatorKerasEmbedding(EstimatorKeras):
 
         elif mode == 'gradient_method':  # TODO depreceate this code
             # Prepare data reading according to whether anndata is backed or not:
-            cell_to_class = self._get_class_dict(obs_key=self._adata_ids.cellontology_class)
+            cell_to_class = self._get_class_dict(obs_key=self._adata_ids.cell_type)
             if self.using_store:
                 n_features = self.data.n_vars
                 generator_raw = self.data.generator(
                     idx=idx,
                     batch_size=1,
-                    obs_keys=[self._adata_ids.cellontology_class],
+                    obs_keys=[self._adata_ids.cell_type],
                     return_dense=True,
                 )
 
@@ -758,7 +758,7 @@ class EstimatorKerasEmbedding(EstimatorKeras):
                             x_sample = x_sample.todense()
                         x_sample = np.asarray(x_sample).flatten()
                         sf_sample = prepare_sf(x=x_sample)[0]
-                        y_sample = z[1][self._adata_ids.cellontology_class].values[0]
+                        y_sample = z[1][self._adata_ids.cell_type].values[0]
                         yield (x_sample, sf_sample), (x_sample, cell_to_class[y_sample])
 
             elif isinstance(self.data, anndata.AnnData) and self.data.isbacked:
@@ -771,14 +771,14 @@ class EstimatorKerasEmbedding(EstimatorKeras):
                     for i in idx:
                         x_sample = self.data.X[i, :].toarray().flatten() if sparse else self.data.X[i, :].flatten()
                         sf_sample = prepare_sf(x=x_sample)[0]
-                        y_sample = self.data.obs[self._adata_ids.cellontology_id][i]
+                        y_sample = self.data.obs[self._adata_ids.cell_type_id][i]
                         yield (x_sample, sf_sample), (x_sample, cell_to_class[y_sample])
             else:
                 if idx is None:
                     idx = np.arange(0, self.data.n_obs)
                 x = self._prepare_data_matrix(idx=idx)
                 sf = prepare_sf(x=x)
-                y = self.data.obs[self._adata_ids.cellontology_class].values[idx]
+                y = self.data.obs[self._adata_ids.cell_type].values[idx]
                 # for gradients per celltype in compute_gradients_input()
                 n_features = x.shape[1]
 
@@ -967,7 +967,7 @@ class EstimatorKerasEmbedding(EstimatorKeras):
         )
 
         if per_celltype:
-            cell_to_id = self._get_class_dict(obs_key=self._adata_ids.cellontology_class)
+            cell_to_id = self._get_class_dict(obs_key=self._adata_ids.cell_type)
             cell_names = cell_to_id.keys()
             cell_id = cell_to_id.values()
             id_to_cell = dict([(key, value) for (key, value) in zip(cell_id, cell_names)])
@@ -1072,7 +1072,7 @@ class EstimatorKerasCelltype(EstimatorKeras):
                         self._adata_ids.not_a_cell_celltype_identifier,
                         None,  # TODO: it may be possible to remove this in the future
                         np.nan,  # TODO: it may be possible to remove this in the future
-                    ] for x in self.data.obs[self._adata_ids.cellontology_class].values
+                    ] for x in self.data.obs[self._adata_ids.cell_type].values
                 ])[0], :]
             else:
                 assert False
@@ -1163,7 +1163,7 @@ class EstimatorKerasCelltype(EstimatorKeras):
         onehot_encoder = self._one_hot_encoder()
         y = np.concatenate([
             onehot_encoder(z)
-            for z in self.data.obs[self._adata_ids.cellontology_id].values[idx].tolist()
+            for z in self.data.obs[self._adata_ids.cell_type_id].values[idx].tolist()
         ], axis=0)
         # Distribute aggregated class weight for computation of weights:
         freq = np.mean(y / np.sum(y, axis=1, keepdims=True), axis=0, keepdims=True)
@@ -1228,7 +1228,7 @@ class EstimatorKerasCelltype(EstimatorKeras):
             generator_raw, _ = self.data.generator(
                 idx=idx,
                 batch_size=batch_size,
-                obs_keys=[self._adata_ids.cellontology_id],
+                obs_keys=[self._adata_ids.cell_type_id],
                 return_dense=True,
                 randomized_batch_access=randomized_batch_access,
             )
@@ -1242,7 +1242,7 @@ class EstimatorKerasCelltype(EstimatorKeras):
                         x_sample = x_sample.todense()
                     x_sample = np.asarray(x_sample)
                     if yield_labels:
-                        y_sample = onehot_encoder(z[1][self._adata_ids.cellontology_id].values)
+                        y_sample = onehot_encoder(z[1][self._adata_ids.cell_type_id].values)
                         for i in range(x_sample.shape[0]):
                             if y_sample[i].sum() > 0:
                                 yield x_sample[i], y_sample[i], 1.

--- a/sfaira/train/summaries.py
+++ b/sfaira/train/summaries.py
@@ -911,7 +911,7 @@ class SummarizeGridsearchCelltype(GridsearchContainer):
         store.subset(attr_key="id", values=[k for k in store.indices.keys()
                                             if 'cell_ontology_class' in store.adata_by_key[k].obs.columns])
         store.subset(attr_key="cellontology_class", excluded_values=[
-            store._adata_ids_sfaira.unknown_celltype_identifier,
+            store._adata_ids_sfaira.unknown_metadata_identifier,
             store._adata_ids_sfaira.not_a_cell_celltype_identifier,
         ])
         cu = CelltypeUniverse(
@@ -1076,7 +1076,7 @@ class SummarizeGridsearchCelltype(GridsearchContainer):
         store.subset(attr_key="id", values=[k for k in store.indices.keys()
                                             if 'cell_ontology_id' in store.adata_by_key[k].obs.columns])
         store.subset(attr_key="cellontology_class", excluded_values=[
-            store._adata_ids_sfaira.unknown_celltype_identifier,
+            store._adata_ids_sfaira.unknown_metadata_identifier,
             store._adata_ids_sfaira.not_a_cell_celltype_identifier,
         ])
         cu = CelltypeUniverse(
@@ -1426,7 +1426,7 @@ class SummarizeGridsearchEmbedding(GridsearchContainer):
                 store.subset(attr_key="id", values=[k for k in store.indices.keys()
                                                     if 'cell_ontology_id' in store.adata_by_key[k].obs.columns])
                 store.subset(attr_key="cellontology_class", excluded_values=[
-                    store._adata_ids_sfaira.unknown_celltype_identifier,
+                    store._adata_ids_sfaira.unknown_metadata_identifier,
                     store._adata_ids_sfaira.not_a_cell_celltype_identifier,
                 ])
                 adatas = store.adata_sliced

--- a/sfaira/train/train_model.py
+++ b/sfaira/train/train_model.py
@@ -242,6 +242,6 @@ class TrainModelCelltype(TrainModel):
         with open(fn + "_topology.pickle", "wb") as f:
             pickle.dump(obj=self.topology_dict, file=f)
 
-        cell_counts = obs['cell_ontology_class'].value_counts().to_dict()
+        cell_counts = obs['cell_type'].value_counts().to_dict()
         with open(fn + '_celltypes_valuecounts_wholedata.pickle', 'wb') as f:
             pickle.dump(obj=[cell_counts], file=f)

--- a/sfaira/unit_tests/data_for_tests/loaders/loaders/dno_doi_mock1/human_lung_2021_10xtechnology_mock1_001.yaml
+++ b/sfaira/unit_tests/data_for_tests/loaders/loaders/dno_doi_mock1/human_lung_2021_10xtechnology_mock1_001.yaml
@@ -44,7 +44,7 @@ dataset_or_observation_wise:
     tech_sample:
     tech_sample_obs_key:
 observation_wise:
-    cell_types_original_obs_key: "free_annotation"
+    cell_type_obs_key: "free_annotation"
 feature_wise:
     gene_id_ensembl_var_key: "index"
     gene_id_symbols_var_key:

--- a/sfaira/unit_tests/data_for_tests/loaders/loaders/dno_doi_mock2/mouse_pancreas_2021_10xtechnology_mock2_001.yaml
+++ b/sfaira/unit_tests/data_for_tests/loaders/loaders/dno_doi_mock2/mouse_pancreas_2021_10xtechnology_mock2_001.yaml
@@ -44,7 +44,7 @@ dataset_or_observation_wise:
     tech_sample:
     tech_sample_obs_key:
 observation_wise:
-    cell_types_original_obs_key: "free_annotation"
+    cell_type_obs_key: "free_annotation"
 feature_wise:
     gene_id_ensembl_var_key: "index"
     gene_id_symbols_var_key:

--- a/sfaira/unit_tests/data_for_tests/loaders/loaders/dno_doi_mock3/human_lung_2021_10xtechnology_mock3_001.yaml
+++ b/sfaira/unit_tests/data_for_tests/loaders/loaders/dno_doi_mock3/human_lung_2021_10xtechnology_mock3_001.yaml
@@ -44,7 +44,7 @@ dataset_or_observation_wise:
     tech_sample:
     tech_sample_obs_key:
 observation_wise:
-    cell_types_original_obs_key: "free_annotation"
+    cell_type_obs_key: "free_annotation"
 feature_wise:
     gene_id_ensembl_var_key: "index"
     gene_id_symbols_var_key:

--- a/sfaira/unit_tests/data_for_tests/loaders/loaders/super_group.py
+++ b/sfaira/unit_tests/data_for_tests/loaders/loaders/super_group.py
@@ -51,7 +51,7 @@ class DatasetSuperGroupMock(DatasetSuperGroup):
                                     sample_fns=None,
                                     yaml_path=fn_yaml,
                                 )
-                                x.load_ontology_class_map(fn=os.path.join(path_module, file_module + ".tsv"))
+                                x.read_ontology_class_map(fn=os.path.join(path_module, file_module + ".tsv"))
                                 datasets.append(x)
                             else:
                                 warn(f"DatasetGroupDirectoryOriented was None for {f}")

--- a/sfaira/unit_tests/tests_by_submodule/data/test_databases.py
+++ b/sfaira/unit_tests/tests_by_submodule/data/test_databases.py
@@ -3,6 +3,7 @@ import pytest
 import shutil
 from typing import List
 
+from sfaira.consts import AdataIdsCellxgene
 from sfaira.unit_tests.directories import DIR_DATA_DATABASES_CACHE
 from sfaira.unit_tests.data_for_tests.databases.utils import prepare_dsg_database
 from sfaira.unit_tests.data_for_tests.databases.consts import CELLXGENE_DATASET_ID
@@ -59,3 +60,23 @@ def test_dsgs_streamline_features(database: str, subset_args: List[str], match_t
     dsg.subset(key=subset_args[0], values=subset_args[1])
     dsg.load()
     dsg.streamline_features(match_to_reference=match_to_reference, subset_genes_to_type=subset_genes_to_type)
+
+
+@pytest.mark.parametrize("database", ["cellxgene", ])
+@pytest.mark.parametrize("subset_args", [["id", CELLXGENE_DATASET_ID], ])
+@pytest.mark.parametrize("format", ["sfaira", ])
+def test_dsgs_streamline_metadata(database: str, subset_args: List[str], format: str):
+    dsg = prepare_dsg_database(database=database)
+    dsg.subset(key=subset_args[0], values=subset_args[1])
+    dsg.load()
+    dsg.streamline_features(match_to_reference={"human": ASSEMBLY_HUMAN, "mouse": ASSEMBLY_MOUSE},
+                            subset_genes_to_type="protein_coding")
+    dsg.streamline_metadata(schema=format)
+    adata = dsg.datasets[subset_args[1]].adata
+    ids = AdataIdsCellxgene()
+    assert "CL:0000128" in adata.obs[ids.cell_type + ids.ontology_id_suffix].values
+    assert "oligodendrocyte" in adata.obs[ids.cell_type].values
+    assert "HsapDv:0000087" in adata.obs[ids.development_stage + ids.ontology_id_suffix].values
+    assert "human adult stage" in adata.obs[ids.development_stage].values
+    assert "UBERON:0000956" in adata.obs[ids.organ + ids.ontology_id_suffix].values
+    assert "cerebral cortex" in adata.obs[ids.organ].values

--- a/sfaira/unit_tests/tests_by_submodule/data/test_databases.py
+++ b/sfaira/unit_tests/tests_by_submodule/data/test_databases.py
@@ -3,7 +3,7 @@ import pytest
 import shutil
 from typing import List
 
-from sfaira.consts import AdataIdsCellxgene
+from sfaira.consts import AdataIdsSfaira
 from sfaira.unit_tests.directories import DIR_DATA_DATABASES_CACHE
 from sfaira.unit_tests.data_for_tests.databases.utils import prepare_dsg_database
 from sfaira.unit_tests.data_for_tests.databases.consts import CELLXGENE_DATASET_ID
@@ -73,10 +73,10 @@ def test_dsgs_streamline_metadata(database: str, subset_args: List[str], format:
                             subset_genes_to_type="protein_coding")
     dsg.streamline_metadata(schema=format)
     adata = dsg.datasets[subset_args[1]].adata
-    ids = AdataIdsCellxgene()
-    assert "CL:0000128" in adata.obs[ids.cell_type + ids.ontology_id_suffix].values
+    ids = AdataIdsSfaira()
+    assert "CL:0000128" in adata.obs[ids.cell_type + ids.onto_id_suffix].values
     assert "oligodendrocyte" in adata.obs[ids.cell_type].values
-    assert "HsapDv:0000087" in adata.obs[ids.development_stage + ids.ontology_id_suffix].values
+    assert "HsapDv:0000087" in adata.obs[ids.development_stage + ids.onto_id_suffix].values
     assert "human adult stage" in adata.obs[ids.development_stage].values
-    assert "UBERON:0000956" in adata.obs[ids.organ + ids.ontology_id_suffix].values
+    assert "UBERON:0000956" in adata.obs[ids.organ + ids.onto_id_suffix].values
     assert "cerebral cortex" in adata.obs[ids.organ].values

--- a/sfaira/unit_tests/tests_by_submodule/data/test_dataset.py
+++ b/sfaira/unit_tests/tests_by_submodule/data/test_dataset.py
@@ -85,8 +85,8 @@ def test_dsgs_subset_cell_wise(organ: str, celltype: str):
         for k, v in x.datasets.items():
             assert v.organism == "mouse", v.id
             assert v.ontology_container_sfaira.organ.is_a(query=v.organ, reference=organ), v.organ
-            for y in np.unique(v.adata.obs[v._adata_ids.cellontology_class].values):
-                assert v.ontology_container_sfaira.cellontology_class.is_a(query=y, reference=celltype), y
+            for y in np.unique(v.adata.obs[v._adata_ids.cell_type].values):
+                assert v.ontology_container_sfaira.cell_type.is_a(query=y, reference=celltype), y
 
 
 @pytest.mark.parametrize("out_format", ["sfaira", "cellxgene"])

--- a/sfaira/unit_tests/tests_by_submodule/data/test_store.py
+++ b/sfaira/unit_tests/tests_by_submodule/data/test_store.py
@@ -156,7 +156,7 @@ def test_config(store_format: str):
 @pytest.mark.parametrize("idx", [np.arange(1, 10),
                                  np.concatenate([np.arange(30, 50), np.array([1, 4, 98])])])
 @pytest.mark.parametrize("batch_size", [1, 7])
-@pytest.mark.parametrize("obs_keys", [["cell_ontology_class"]])
+@pytest.mark.parametrize("obs_keys", [["cell_type"]])
 @pytest.mark.parametrize("randomized_batch_access", [True, False])
 def test_generator_shapes(store_format: str, idx, batch_size: int, obs_keys: List[str], randomized_batch_access: bool):
     """

--- a/sfaira/unit_tests/tests_by_submodule/estimators/test_estimator.py
+++ b/sfaira/unit_tests/tests_by_submodule/estimators/test_estimator.py
@@ -243,7 +243,7 @@ class TestHelperEstimatorKerasCelltype(TestHelperEstimatorKeras):
         )
         leaves = self.estimator.celltype_universe.onto_cl.get_effective_leaves(
             x=[x for x in self.data.obs[self.adata_ids.cell_type].values
-               if x != self.adata_ids.unknown_celltype_identifier]
+               if x != self.adata_ids.unknown_metadata_identifier]
         )
         self.nleaves = len(leaves)
         self.estimator.celltype_universe.onto_cl.leaves = leaves
@@ -297,7 +297,8 @@ class HelperEstimatorKerasCelltypeCustomObo(TestHelperEstimatorKerasCelltype):
             self.custom_types[np.random.randint(0, len(self.custom_types))]
             for _ in range(self.data.n_obs)
         ]
-        self.data.obs[self.adata_ids.cell_type_id] = self.data.obs[self.adata_ids.cell_type]
+        self.data.obs[self.adata_ids.cell_type + self.adata_ids.onto_id_suffix] = \
+            self.data.obs[self.adata_ids.cell_type]
         # - Add in custom features:
         self.data.var_names = ["dim_" + str(i) for i in range(self.data.n_vars)]
         self.data.var[self.adata_ids.gene_id_ensembl] = ["dim_" + str(i) for i in range(self.data.n_vars)]

--- a/sfaira/unit_tests/tests_by_submodule/estimators/test_estimator.py
+++ b/sfaira/unit_tests/tests_by_submodule/estimators/test_estimator.py
@@ -242,7 +242,7 @@ class TestHelperEstimatorKerasCelltype(TestHelperEstimatorKeras):
             model_topology=tc
         )
         leaves = self.estimator.celltype_universe.onto_cl.get_effective_leaves(
-            x=[x for x in self.data.obs[self.adata_ids.cellontology_class].values
+            x=[x for x in self.data.obs[self.adata_ids.cell_type].values
                if x != self.adata_ids.unknown_celltype_identifier]
         )
         self.nleaves = len(leaves)
@@ -293,11 +293,11 @@ class HelperEstimatorKerasCelltypeCustomObo(TestHelperEstimatorKerasCelltype):
         # - Subset to target feature space size:
         self.data = self.data[:, :self.tc.gc.n_var].copy()
         # - Add in custom cell types:
-        self.data.obs[self.adata_ids.cellontology_class] = [
+        self.data.obs[self.adata_ids.cell_type] = [
             self.custom_types[np.random.randint(0, len(self.custom_types))]
             for _ in range(self.data.n_obs)
         ]
-        self.data.obs[self.adata_ids.cellontology_id] = self.data.obs[self.adata_ids.cellontology_class]
+        self.data.obs[self.adata_ids.cell_type_id] = self.data.obs[self.adata_ids.cell_type]
         # - Add in custom features:
         self.data.var_names = ["dim_" + str(i) for i in range(self.data.n_vars)]
         self.data.var[self.adata_ids.gene_id_ensembl] = ["dim_" + str(i) for i in range(self.data.n_vars)]

--- a/sfaira/unit_tests/tests_by_submodule/ui/test_userinterface.py
+++ b/sfaira/unit_tests/tests_by_submodule/ui/test_userinterface.py
@@ -38,6 +38,9 @@ class HelperUi:
         self.ui = UserInterface(custom_repo=temp_fn, sfaira_repo=False)
 
 
-def test_for_fatal():
+def _test_for_fatal():
+    """
+    TODO need to simulate/add look up table as part of unit tests locally
+    """
     ui = HelperUi()
     ui.test_basic()

--- a/sfaira/unit_tests/tests_by_submodule/ui/test_userinterface.py
+++ b/sfaira/unit_tests/tests_by_submodule/ui/test_userinterface.py
@@ -6,7 +6,7 @@ from sfaira.ui import UserInterface
 from sfaira.unit_tests import DIR_TEMP
 
 
-class TestUi:
+class HelperUi:
     ui: Union[UserInterface]
     data: np.ndarray
 
@@ -27,7 +27,7 @@ class TestUi:
         """
         pass
 
-    def _test_basic(self):
+    def test_basic(self):
         """
         Test all relevant model methods.
 
@@ -36,3 +36,8 @@ class TestUi:
         """
         temp_fn = os.path.join(DIR_TEMP, "test_data")
         self.ui = UserInterface(custom_repo=temp_fn, sfaira_repo=False)
+
+
+def test_for_fatal():
+    ui = HelperUi()
+    ui.test_basic()


### PR DESCRIPTION
- includes bug fix that lead to missing meta data import from cellxgene structured data sets
- simplified meta data streamlining code and enhanced code readability
- depreceated distinction between cell type and cell type original in data set definition in favor of single attribute
- allowed all ontology constrained meta data items to be supplied in any format (original + mapl, symbol, or id) via the *_obs_col attribute of the loader
- removed resetting of _obs_col attributes in streamlining in favor of adataids controlled obs col names that extend to IDs and original labels
- updated cell type entry in all data loaders