### PR TITLE
deleted 'download_url_meta' from multiple_datasets and single_dataset…

### DIFF
--- a/sfaira/commands/templates/multiple_datasets/{{ cookiecutter.doi_sfaira_repr }}/{{ cookiecutter.id_without_doi }}.yaml
+++ b/sfaira/commands/templates/multiple_datasets/{{ cookiecutter.doi_sfaira_repr }}/{{ cookiecutter.id_without_doi }}.yaml
@@ -10,9 +10,8 @@ dataset_structure:
     doi_journal: "{{ cookiecutter.doi }}"
     download_url_data:
 {% for fn in cookiecutter.sample_fns.fns %}        {{ fn }}:
-{% endfor %}    download_url_meta:
-{% for fn in cookiecutter.sample_fns.fns %}        {{ fn }}:
-{% endfor %}    primary_data: {{ cookiecutter.primary_data }}
+{% endfor %}
+    primary_data: {{ cookiecutter.primary_data }}
     normalization: "{{ cookiecutter.normalization }}"
     year: {{ cookiecutter.year }}
 dataset_or_observation_wise:

--- a/sfaira/commands/templates/single_dataset/{{ cookiecutter.doi_sfaira_repr }}/{{ cookiecutter.id_without_doi }}.yaml
+++ b/sfaira/commands/templates/single_dataset/{{ cookiecutter.doi_sfaira_repr }}/{{ cookiecutter.id_without_doi }}.yaml
@@ -8,7 +8,6 @@ dataset_wise:
     doi_preprint:
     doi_journal: "{{ cookiecutter.doi }}"
     download_url_data: "{{ cookiecutter.download_url_data }}"
-    download_url_meta: "{{ cookiecutter.download_url_meta }}"
     primary_data: {{ cookiecutter.primary_data }}
     normalization: "{{ cookiecutter.normalization }}"
     year: {{ cookiecutter.year }}


### PR DESCRIPTION
… cookiecutter yaml files

Many thanks for contributing to sfaira!

**PR Checklist**

 - [x] This comment contains a description of changes (with reason)
 - [?] If you've fixed a bug or added code that should be tested, add tests!
 - [?] Documentation in `docs` is updated
 - [?] `docs/release-notes.rst` is updated

**Description of changes**
I deleted the ```download_url_meta:``` fields in ```sfaira/sfaira/commands/templates/single_dataset/\{\{\ cookiecutter.doi_sfaira_repr\ \}\}/\{\{\ cookiecutter.id_without_doi\ \}\}.yaml```and ```sfaira/sfaira/commands/templates/multiple_datasets/\{\{\ cookiecutter.doi_sfaira_repr\ \}\}/\{\{\ cookiecutter.id_without_doi\ \}\}.yaml```
