### PR TITLE
Feature/persist data to memory for dao_store

### DIFF
--- a/sfaira/data/store/load_store.py
+++ b/sfaira/data/store/load_store.py
@@ -5,8 +5,10 @@ from sfaira.data.store.multi_store import DistributedStoresDao, DistributedStore
     DistributedStoreMultipleFeatureSpaceBase
 
 
-def load_store(cache_path: Union[str, os.PathLike], store_format: str = "dao",
-               columns: Union[None, List[str]] = None) -> DistributedStoreMultipleFeatureSpaceBase:
+def load_store(cache_path: Union[str, os.PathLike], 
+               store_format: str = "dao",
+               columns: Union[None, List[str]] = None,
+               persist_data_to_memory: bool = False) -> DistributedStoreMultipleFeatureSpaceBase:
     """
     Instantiates a distributed store class.
 
@@ -22,12 +24,14 @@ def load_store(cache_path: Union[str, os.PathLike], store_format: str = "dao",
             "h5ad".
     :param columns: Which columns to read into the obs copy in the output, see pandas.read_parquet().
         Only relevant if store_format is "dao".
+    :param persist_data_to_memory: Whether to persist data into memory (in sparse format)
+        Only relevant if store_format is "dao"
     :return: Instances of a distributed store class.
     """
     if store_format == "h5ad":
         return DistributedStoresH5ad(cache_path=cache_path, in_memory=True)
     elif store_format == "dao":
-        return DistributedStoresDao(cache_path=cache_path, columns=columns)
+        return DistributedStoresDao(cache_path=cache_path, columns=columns, persist_to_memory=persist_data_to_memory)
     elif store_format == "h5ad_backed":
         return DistributedStoresH5ad(cache_path=cache_path, in_memory=False)
     else:

--- a/sfaira/data/store/multi_store.py
+++ b/sfaira/data/store/multi_store.py
@@ -285,11 +285,15 @@ class DistributedStoresDao(DistributedStoreMultipleFeatureSpaceBase):
 
     _dataset_weights: Union[None, Dict[str, float]]
 
-    def __init__(self, cache_path: Union[str, os.PathLike], columns: Union[None, List[str]] = None):
+    def __init__(self, 
+                 cache_path: Union[str, os.PathLike], 
+                 columns: Union[None, List[str]] = None,
+                 persist_to_memory: bool = False):
         """
 
         :param cache_path: Store directory.
         :param columns: Which columns to read into the obs copy in the output, see pandas.read_parquet().
+        :param persist_to_memory: Whether to persist the data into memory (in sparse format)
         """
         # Collect all data loaders from files in directory:
         self._adata_ids_sfaira = AdataIdsSfaira()
@@ -316,7 +320,7 @@ class DistributedStoresDao(DistributedStoreMultipleFeatureSpaceBase):
         self._x_by_key = x_by_key
         stores = dict([
             (k, DistributedStoreDao(adata_by_key=adata_by_key[k], x_by_key=x_by_key[k], indices=indices[k],
-                                    obs_by_key=None))
+                                    obs_by_key=None, persist_to_memory=persist_to_memory))
             for k in adata_by_key.keys()
         ])
         super(DistributedStoresDao, self).__init__(stores=stores)

--- a/sfaira/data/store/single_store.py
+++ b/sfaira/data/store/single_store.py
@@ -3,6 +3,7 @@ import anndata
 import dask.array
 import dask.dataframe
 import numpy as np
+import sparse
 import os
 import pandas as pd
 import pickle
@@ -696,11 +697,12 @@ class DistributedStoreDao(DistributedStoreSingleFeatureSpace):
     _x: Union[None, dask.array.Array]
     _x_by_key: Union[None, dask.array.Array]
 
-    def __init__(self, x_by_key, **kwargs):
+    def __init__(self, x_by_key, persist_to_memory=False, **kwargs):
         super(DistributedStoreDao, self).__init__(**kwargs)
         self._x = None
         self._x_as_dask = True
         self._x_by_key = x_by_key
+        self._persist_to_memory = persist_to_memory
 
     @property
     def indices(self) -> Dict[str, np.ndarray]:
@@ -753,8 +755,12 @@ class DistributedStoreDao(DistributedStoreSingleFeatureSpace):
                     else:
                         arrs_to_concat.append(self._x_by_key[k][v, :])
                 self._x = dask.optimize(dask.array.vstack(arrs_to_concat))[0]
+
+                if self._persist_to_memory:
+                    self._x = self._x.map_blocks(sparse.COO).persist()
             else:
                 raise ValueError(f"Did not recognise data_source={self.data_source}.")
+
         return self._x
 
     @property


### PR DESCRIPTION
**Description of changes**
Added functionality to persist dask array into memory in sparse.COO format for DistributedStoreDao. 

**Technical details**
If selected, dask.array of DistributedStoreDao is persisted into memory in sparse.COO format via `.map_blocks(sprase.COO).persist()`. Persisting is done in DistributedStoreDao class, as this way, more than one generator can use the same underlying persisted dask array and the data does not have to be persisted into memory for each generator. 

**Additional context**
This is just a draft. Let me know if you have any suggestions @davidsebfischer. If draft looks good, I'll test the code more thoroughly. 
