### PR TITLE
Feature: Option to shuffle datasets before writing dao stores

### DIFF
--- a/sfaira/data/dataloaders/base/dataset.py
+++ b/sfaira/data/dataloaders/base/dataset.py
@@ -913,8 +913,9 @@ class DatasetBase(abc.ABC):
             dir_cache: Union[str, os.PathLike],
             store_format: str = "dao",
             dense: bool = False,
-            compression_kwargs: dict = {},
+            compression_kwargs: Union[dict, None] = None,
             chunks: Union[int, None] = None,
+            shuffle_data: bool = False
     ):
         """
         Write data set into a format that allows distributed access to data set on disk.
@@ -943,7 +944,10 @@ class DatasetBase(abc.ABC):
         :param chunks: Observation axes of chunk size of zarr array, see anndata.AnnData.write_zarr documentation.
             Only relevant for store=="dao". The feature dimension of the chunks is always is the full feature space.
             Uses zarr default chunking across both axes if None.
+        :param shuffle_data: If True -> shuffle datasets before writing store
         """
+        if compression_kwargs is None:
+            compression_kwargs = {}
         self.__assert_loaded()
         if store_format == "h5ad":
             if not isinstance(self.adata.X, scipy.sparse.csr_matrix):
@@ -960,7 +964,8 @@ class DatasetBase(abc.ABC):
                                  "consider writing as dense and consider that zarr arrays are compressed on disk!")
             fn = os.path.join(dir_cache, self.doi_cleaned_id)
             chunks = (chunks, self.adata.X.shape[1]) if chunks is not None else True
-            write_dao(store=fn, adata=self.adata, chunks=chunks, compression_kwargs=compression_kwargs)
+            write_dao(store=fn, adata=self.adata, chunks=chunks, compression_kwargs=compression_kwargs,
+                      shuffle_data=shuffle_data)
         else:
             raise ValueError()
 

--- a/sfaira/data/dataloaders/base/dataset.py
+++ b/sfaira/data/dataloaders/base/dataset.py
@@ -944,7 +944,7 @@ class DatasetBase(abc.ABC):
         :param chunks: Observation axes of chunk size of zarr array, see anndata.AnnData.write_zarr documentation.
             Only relevant for store=="dao". The feature dimension of the chunks is always is the full feature space.
             Uses zarr default chunking across both axes if None.
-        :param shuffle_data: If True -> shuffle datasets before writing store
+        :param shuffle_data: If True -> shuffle ordering of cells in datasets before writing store
         """
         if compression_kwargs is None:
             compression_kwargs = {}

--- a/sfaira/data/store/io/io_dao.py
+++ b/sfaira/data/store/io/io_dao.py
@@ -11,6 +11,12 @@ from typing import List, Tuple, Union
 import zarr
 
 
+def _invert_permutation(p: np.ndarray):
+    s = np.empty_like(p)
+    s[p] = np.arange(p.size)
+    return s
+
+
 def _buffered_path(path_base, path, fn):
     path_base = os.path.join(path_base, path)
     if not os.path.exists(path_base):
@@ -37,7 +43,7 @@ def path_x(path):
 
 
 def write_dao(store: Union[str, Path], adata: anndata.AnnData, chunks: Union[bool, Tuple[int, int]],
-              compression_kwargs: dict):
+              compression_kwargs: dict, shuffle_data: bool = False):
     """
     Writes a distributed access optimised ("dao") store of a dataset based on an AnnData instance.
 
@@ -55,14 +61,22 @@ def write_dao(store: Union[str, Path], adata: anndata.AnnData, chunks: Union[boo
     :param adata: Anndata to save.
     :param chunks: Chunking of .X for zarr.
     :param compression_kwargs: Compression kwargs for zarr.
+    :param shuffle_data: If True -> shuffle dataset (adata) before writing store to disk
     """
     # Write numeric matrix as zarr array:
     f = zarr.open(store=path_x(store), mode="w")
+    if shuffle_data:
+        perm = np.arange(0, adata.X.shape[0])
+        np.random.shuffle(perm)
+        adata.obs['permutation_original_data'] = _invert_permutation(perm)
+    else:
+        perm = np.arange(0, adata.X.shape[0])
+
     # If adata.X is already a dense array in memory, it can be safely written fully to a zarr array. Otherwise:
     # Create empty store and then write in dense chunks to avoid having to load entire adata.X into a dense array in
     # memory.
     if isinstance(adata.X, np.ndarray) or isinstance(adata.X, np.matrix):
-        f.create_dataset("X", data=adata.X.todense(), chunks=chunks, dtype=adata.X.dtype, **compression_kwargs)
+        f.create_dataset("X", data=np.array(adata.X)[perm], chunks=chunks, dtype=adata.X.dtype, **compression_kwargs)
     elif isinstance(adata.X, scipy.sparse.csr_matrix):
         # Initialise empty array
         dtype = adata.X.data.dtype
@@ -71,8 +85,9 @@ def write_dao(store: Union[str, Path], adata: anndata.AnnData, chunks: Union[boo
         batch_size = 128  # Use a batch size that guarantees that the dense batch fits easily into memory.
         n_batches = shape[0] // batch_size + int(shape[0] % batch_size > 0)
         batches = [(i * batch_size, min(i * batch_size + batch_size, shape[0])) for i in range(n_batches)]
+        x_permuted = adata.X[perm]
         for s, e in batches:
-            f["X"][s:e, :] = np.asarray(adata.X[s:e, :].todense(), dtype=dtype)
+            f["X"][s:e, :] = np.asarray(x_permuted[s:e, :].todense(), dtype=dtype)
     else:
         raise ValueError(f"did not recognise array format {type(adata.X)}")
     # Write .uns into pickle:
@@ -80,7 +95,7 @@ def write_dao(store: Union[str, Path], adata: anndata.AnnData, chunks: Union[boo
         # convert to dict to get rid of anndata OverloadedDict
         pickle.dump(obj=dict(adata.uns), file=f)
     # Write .obs and .var as a separate file as this can be easily interfaced with DataFrames.
-    adata.obs.to_parquet(path=path_obs(store), engine='pyarrow', compression='snappy', index=None)
+    adata.obs.iloc[perm].to_parquet(path=path_obs(store), engine='pyarrow', compression='snappy', index=None)
     adata.var.to_parquet(path=path_var(store), engine='pyarrow', compression='snappy', index=None)
 
 

--- a/sfaira/data/store/io/io_dao.py
+++ b/sfaira/data/store/io/io_dao.py
@@ -61,7 +61,7 @@ def write_dao(store: Union[str, Path], adata: anndata.AnnData, chunks: Union[boo
     :param adata: Anndata to save.
     :param chunks: Chunking of .X for zarr.
     :param compression_kwargs: Compression kwargs for zarr.
-    :param shuffle_data: If True -> shuffle dataset (adata) before writing store to disk
+    :param shuffle_data: If True -> shuffle ordering of cells in dataset before writing store to disk
     """
     # Write numeric matrix as zarr array:
     f = zarr.open(store=path_x(store), mode="w")

--- a/sfaira/data/utils_scripts/write_store.py
+++ b/sfaira/data/utils_scripts/write_store.py
@@ -1,35 +1,40 @@
+import argparse
 import os
+
 import sfaira
-import sys
 
-# Set global variables.
-print("sys.argv", sys.argv)
 
-data_path = str(sys.argv[1])
-path_meta = str(sys.argv[2])
-path_cache = str(sys.argv[3])
-path_store = str(sys.argv[4])
-store_type = str(sys.argv[5]).lower()
+parser = argparse.ArgumentParser()
+parser.add_argument('--data_path', type=str)
+parser.add_argument('--path_meta', type=str)
+parser.add_argument('--path_cache', type=str)
+parser.add_argument('--path_store', type=str)
+parser.add_argument('--store_type', type=str)
+parser.add_argument('--chunks', type=int, default=128)
+parser.add_argument('--shuffle_data', type=lambda x: str(x).lower() in ['true', '1', 'yes'], default=True)
+args = parser.parse_args()
 
 # On disk format hyperparameters
-if store_type == "h5ad":
+if args.store_type == "h5ad":
     # Write sparse arrays in h5ad.
     kwargs = {"dense": False}
     compression_kwargs = {}
-elif store_type == "dao":
+elif args.store_type == "dao":
     # Write dense arrays in zarr.
-    kwargs = {"dense": True, "chunks": 128}
+    kwargs = {"dense": True, "chunks": args.chunks, "shuffle_data": args.shuffle_data}
     compression_kwargs = {"compressor": "default", "overwrite": True, "order": "C"}
 else:
-    assert False, store_type
+    assert False, args.store_type
 
-universe = sfaira.data.dataloaders.Universe(data_path=data_path, meta_path=path_meta, cache_path=path_cache)
+universe = sfaira.data.dataloaders.Universe(data_path=args.data_path,
+                                            meta_path=args.path_meta,
+                                            cache_path=args.path_cache)
 
 for k, ds in universe.datasets.items():
-    if store_type == "h5ad":
-        fn_store = os.path.join(path_store, ds.doi_cleaned_id + ".h5ad")
-    elif store_type == "dao":
-        fn_store = os.path.join(path_store, ds.doi_cleaned_id)
+    if args.store_type == "h5ad":
+        fn_store = os.path.join(args.path_store, ds.doi_cleaned_id + ".h5ad")
+    elif args.store_type == "dao":
+        fn_store = os.path.join(args.path_store, ds.doi_cleaned_id)
     else:
         assert False
     if os.path.exists(fn_store):
@@ -46,6 +51,6 @@ for k, ds in universe.datasets.items():
             subset_genes_to_type="protein_coding"
         )
         ds.streamline_metadata(schema="sfaira", clean_obs=True, clean_var=True, clean_uns=True, clean_obs_names=True)
-        ds.write_distributed_store(dir_cache=path_store, store_format=store_type, compression_kwargs=compression_kwargs,
-                                   **kwargs)
+        ds.write_distributed_store(dir_cache=args.path_store, store_format=args.store_type,
+                                   compression_kwargs=compression_kwargs, **kwargs)
         ds.clear()


### PR DESCRIPTION
**Description of changes**

* Added option to shuffle individual datasets before writing dao store
* If shuffling is enabled and extra obs column `permutation_original_data` is created that one can easily get back the order of the original data by `X[obs.permutation_original_data]`
* Chunk size of dao store is now a configurable parameter
