### PR TITLE
Feature/url check

### DIFF
--- a/.github/workflows/check_urls.yml
+++ b/.github/workflows/check_urls.yml
@@ -1,0 +1,25 @@
+name: Check URLs
+
+on:
+  schedule:
+    - cron: "0 0 * * *" #runs at 00:00 UTC everyday
+  workflow_dispatch:
+
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout repo content
+        uses: actions/checkout@v2
+      - name: setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.8
+
+      - name: Build sfaira
+        run: pip install .
+
+      - name: check URLs
+        run: python ./scripts/check_urls.py

--- a/scripts/check_urls.py
+++ b/scripts/check_urls.py
@@ -1,0 +1,18 @@
+import itertools
+import urllib
+
+import sfaira
+
+u = sfaira.data.Universe()
+urls = []
+for x in u.datasets.values():
+    a = x.download_url_data
+    if a is not None:
+        urls.append(a) if isinstance(a, str) else urls.extend(a)
+    b = x.download_url_meta
+    if b is not None:
+        urls.append(b) if isinstance(b, str) else urls.extend(b)
+
+flat_urls = list(filter(lambda url: url is not None, list(itertools.chain(*urls))))
+for url in flat_urls:
+    assert urllib.request.urlopen(url).getcode() == 200


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/home/zeth/PycharmProjects/sfaira/scripts/check_urls.py", line 29, in <module>
    raise AssertionError(f"{len(failed_urls)} URLs failed.")
AssertionError: 15 URLs failed.
[['https://advances.sciencemag.org/highwire/filestream/234522/field_highwire_adjunct_files/2/aba1972_Table_S2.csv', <HTTPError 403: 'Forbidden'>], ['https://cellgeni.cog.sanger.ac.uk/BenKidney_v2.1/Mature_Full_v2.1.h5ad', <HTTPError 404: 'Not Found'>], ['https://cellgeni.cog.sanger.ac.uk/BenKidney_v2.1/Fetal_full.h5ad', <HTTPError 404: 'Not Found'>], ['https://data.humancellatlas.org/project-assets/project-matrices/cc95ff89-2e68-4a08-a234-480eca21ce79.homo_sapiens.loom', <HTTPError 404: 'Not Found'>], ['https://www.science.org/doi/suppl/10.1126/sciimmunol.abd1554/suppl_file/table_s1.xlsx', <HTTPError 403: 'Forbidden'>], ['http://cf.10xgenomics.com/samples/cell-exp/3.0.0/pbmc_10k_v3/pbmc_10k_v3_filtered_feature_bc_matrix.h5', <HTTPError 403: 'Forbidden'>], ['https://czb-tabula-muris-senis.s3-us-west-2.amazonaws.com/Data-objects/tabula-muris-senis-facs-processed-official-annotations-SCAT.h5ad', URLError(TimeoutError(110, 'Connection timed out'))], ['https://czb-tabula-muris-senis.s3-us-west-2.amazonaws.com/Data-objects/tabula-muris-senis-droplet-processed-official-annotations-Marrow.h5ad', URLError(TimeoutError(110, 'Connection timed out'))], ['https://czb-tabula-muris-senis.s3-us-west-2.amazonaws.com/Data-objects/tabula-muris-senis-droplet-processed-official-annotations-Tongue.h5ad', URLError(TimeoutError(110, 'Connection timed out'))], ['https://beta.fastgenomics.org/p/schulte-schrepping_covid19', <HTTPError 404: 'Not Found'>], ['https://beta.fastgenomics.org/p/schulte-schrepping_covid19', <HTTPError 404: 'Not Found'>], ['https://beta.fastgenomics.org/p/schulte-schrepping_covid19', <HTTPError 404: 'Not Found'>], ['https://beta.fastgenomics.org/p/schulte-schrepping_covid19', <HTTPError 404: 'Not Found'>], ['https://beta.fastgenomics.org/p/schulte-schrepping_covid19', <HTTPError 404: 'Not Found'>], ['https://beta.fastgenomics.org/p/schulte-schrepping_covid19', <HTTPError 404: 'Not Found'>]]
```

