### PR TITLE
Bug fix: d10_1164_rccm_201712_2410OC

### DIFF
--- a/sfaira/data/dataloaders/loaders/d10_1164_rccm_201712_2410OC/homosapiens_lung_2018_10x3v2_reyfman_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1164_rccm_201712_2410OC/homosapiens_lung_2018_10x3v2_reyfman_001.py
@@ -13,8 +13,13 @@ def load(data_dir, sample_fn, **kwargs):
     with tarfile.open(fn) as tar:
         f = h5py.File(tar.extractfile(f'{sample_fn}_filtered_gene_bc_matrices_h5.h5'), 'r')['GRCh38']
         x = scipy.sparse.csc_matrix((f['data'], f['indices'], f['indptr']), shape=f['shape']).T
-        var = pd.DataFrame({'feature_id': f['genes'], 'feature_symbol': f['gene_names']})
-        obs = pd.DataFrame({'barcode': f['barcodes']})
+        var = pd.DataFrame({'feature_id': f['genes'], 'feature_symbol': f['gene_names']}).assign(
+            feature_id=lambda xx: xx.feature_id.str.decode('utf-8'),
+            feature_symbol=lambda xx: xx.feature_symbol.str.decode('utf-8')
+        )
+        obs = pd.DataFrame({'barcode': f['barcodes']}).assign(
+            barcode=lambda xx: xx.barcode.str.decode('utf-8')
+        )
         adata = anndata.AnnData(X=x, obs=obs, var=var)
 
     return adata


### PR DESCRIPTION
Strings in `obs` and `var` DataFrames were not decoded, which lead to an error during streamlining
