### PR TITLE
Feature: Improvements to DAO store

### DIFF
--- a/sfaira/data/store/stores/single.py
+++ b/sfaira/data/store/stores/single.py
@@ -8,6 +8,7 @@ import dask.array
 import dask.dataframe
 import numpy as np
 import pandas as pd
+import scipy.sparse
 from sfaira.consts import AdataIdsSfaira, OCS
 from sfaira.data.dataloaders.base.utils import is_child, UNS_STRING_META_IN_OBS
 from sfaira.data.store.carts.single import CartAnndata, CartDask, CartSingle
@@ -656,6 +657,35 @@ class StoreDao(StoreSingleFeatureSpace):
         return CartDask(x=self._x, obs=self._obs, **kwargs)
 
     # Methods that are specific to this child class:
+
+    def move_to_memory(self):
+        """
+        Persist underlying dask array into memory in sparse.CSR format.
+        """
+        if not self._x_dask_cache:
+            self._x_dask_cache = self._x
+
+        self._x_dask_cache = self._x_dask_cache.map_blocks(scipy.sparse.csr_matrix).persist()
+
+    @property
+    def x(self) -> dask.array.Array:
+        """
+        One dask array of all cells.
+
+        Requires feature dimension to be shared.
+        """
+        return self._x
+
+    @property
+    def obs(self) -> pd.DataFrame:
+        """
+        Assemble .obs table of subset of selected data.
+
+        Resulting index is increasing integers starting with zero.
+
+        :return: .obs data frame.
+        """
+        return self._obs
 
     @property
     def _x(self) -> dask.array.Array:


### PR DESCRIPTION
**Description of changes**

- Added option to persist dask.array.Array of DaoStore into memory - this makes sense if you have several carts working on the same underlying. By persisting the store into memory you don't have to persist the data for every cart into memory
- Added public properties for `._x` and `._obs` properties. I've been using those a lot, so would maybe make sense to make those public? 