### PR TITLE
Add support when attributes in yaml files are only specified for subset of sample_fns

### DIFF
--- a/sfaira/data/dataloaders/base/annotation_container.py
+++ b/sfaira/data/dataloaders/base/annotation_container.py
@@ -105,9 +105,6 @@ class AnnotationContainer:
                         if sample_fn in v.keys():
                             # only set value if field exists
                             v = v[sample_fn]
-                        else:
-                            # otherwise skip field
-                            continue
                     # Catches spelling errors in meta data definition (yaml keys).
                     if not hasattr(self, k) and not hasattr(self, "_" + k):
                         raise ValueError(f"Tried setting unavailable property {k}.")

--- a/sfaira/data/dataloaders/base/annotation_container.py
+++ b/sfaira/data/dataloaders/base/annotation_container.py
@@ -102,8 +102,12 @@ class AnnotationContainer:
             for k, v in yaml_vals["attr"].items():
                 if v is not None and k not in ["organism", "sample_fns"]:
                     if isinstance(v, dict):  # v is a dictionary over file-wise meta-data items
-                        assert sample_fn in v.keys(), f"did not find key {sample_fn} in yamls keys for {k}"
-                        v = v[sample_fn]
+                        if sample_fn in v.keys():
+                            # only set value if field exists
+                            v = v[sample_fn]
+                        else:
+                            # otherwise skip field
+                            continue
                     # Catches spelling errors in meta data definition (yaml keys).
                     if not hasattr(self, k) and not hasattr(self, "_" + k):
                         raise ValueError(f"Tried setting unavailable property {k}.")


### PR DESCRIPTION
**Description of changes**
Currently one has to supply all sample_fns when specifying an attribute in the yaml files, like:
```
sample_fns:
    - test1
    - test2

dataset_or_observation_wise:
    assay_sc:
        test1: "10x"
        test2: "10x2"
```

With this PR one can specify an attribute only for a subset of all `sample_fns`, like: 

```
sample_fns:
    - test1
    - test2

dataset_or_observation_wise:
    assay_sc:
        test1: "10x"
```

