### PR TITLE
data/d10_1016_j_stem_2018_12_015

### DIFF
--- a/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2018_12_015/__init__.py
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2018_12_015/__init__.py
@@ -1,0 +1,1 @@
+FILE_PATH = __file__

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2018_12_015/homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiang_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2018_12_015/homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiang_001.py
@@ -13,8 +13,8 @@ def load(data_dir, **kwargs):
     fn_matrix = os.path.join(data_dir, "GSE122342_matrix.mtx.gz")
     fn_genes = os.path.join(data_dir, "GSE122342_genes.tsv.gz")
     fn_barcodes = os.path.join(data_dir, "GSE122342_barcodes.tsv.gz")
-    fn_schThO_class = os.path.join(data_dir, "schThO_class.txt")  # annotated cell clusters 
-    fn_GSEA_enrich = os.path.join(data_dir, "GSEA_category_enrich.txt")  # gene set enrichment analysis (GSEA) 
+    fn_schThO_class = os.path.join(data_dir, "schThO_class.txt")
+    fn_GSEA_enrich = os.path.join(data_dir, "GSEA_category_enrich.txt")
 
     uncompressed_file_type = "mtx"
     with TemporaryDirectory() as tmpdir:
@@ -23,7 +23,7 @@ def load(data_dir, **kwargs):
             shutil.copyfileobj(input_f, output_f)
         matrix = scipy.io.mmread(fn_matrix)
 
-    genes = pd.read_csv(fn_genes, delimiter='\t', compression='gzip', index_col=0, header = None, names=["ensembl_gene_id", "gene_id"])
+    genes = pd.read_csv(fn_genes, delimiter='\t', compression='gzip', index_col=0, header=None, names=["ensembl_gene_id", "gene_id"])
     barcodes = pd.read_csv(fn_barcodes, delimiter='\t', compression='gzip', index_col=0, header=None)
     barcodes.index.name = None
     metadata1 = pd.read_csv(fn_schThO_class, delimiter='\t', index_col=0)

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2018_12_015/homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiang_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2018_12_015/homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiang_001.py
@@ -1,0 +1,42 @@
+import numpy as np
+import pandas as pd
+import anndata as ad
+import scanpy as sc
+import os
+import scipy
+import gzip
+from tempfile import TemporaryDirectory
+import shutil
+
+
+def load(data_dir, **kwargs):
+    fn_matrix = os.path.join(data_dir, "GSE122342_matrix.mtx.gz")
+    fn_genes = os.path.join(data_dir, "GSE122342_genes.tsv.gz")
+    fn_barcodes = os.path.join(data_dir, "GSE122342_barcodes.tsv.gz")
+    fn_schThO_class = os.path.join(data_dir, "schThO_class.txt")  # annotated cell clusters 
+    fn_GSEA_enrich = os.path.join(data_dir, "GSEA_category_enrich.txt")  # gene set enrichment analysis (GSEA) 
+
+    uncompressed_file_type = "mtx"
+    with TemporaryDirectory() as tmpdir:
+        tmppth = tmpdir + f"/decompressed.{uncompressed_file_type}"
+        with gzip.open(fn_matrix, "rb") as input_f, open(tmppth, "wb") as output_f:
+            shutil.copyfileobj(input_f, output_f)
+        matrix = scipy.io.mmread(fn_matrix)
+
+    genes = pd.read_csv(fn_genes, delimiter='\t', compression='gzip', index_col=0, header = None, names=["ensembl_gene_id", "gene_id"])
+    barcodes = pd.read_csv(fn_barcodes, delimiter='\t', compression='gzip', index_col=0, header=None)
+    barcodes.index.name = None
+    metadata1 = pd.read_csv(fn_schThO_class, delimiter='\t', index_col=0)
+    metadata1["organoid_age_days"] = "34"
+    metadata1.loc[metadata1.Time == "late", "organoid_age_days"] = "89"
+    obs = barcodes.join(metadata1)
+    metadata2 = pd.read_csv(fn_GSEA_enrich, delimiter='\t', index_col=0)
+    obs = obs.join(metadata2)
+
+    adata = ad.AnnData(
+        X=matrix.T,
+        obs=obs,
+        var=genes,)
+    adata
+
+    return adata

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2018_12_015/homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiang_001.yaml
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2018_12_015/homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiang_001.yaml
@@ -1,23 +1,17 @@
 dataset_structure:
     dataset_index: 1
     sample_fns:
-        - "matrix"
-        - "genes"
-        - "barcodes"
-        - "cell_clusters"
-        - "GSEA_enrichment"
 dataset_wise:
     author: "Xiang, Yangfei"
     default_embedding: 
     doi_preprint: 
     doi_journal: "10.1016/j.stem.2018.12.015"
-    download_url_data: "ftp://ftp.ncbi.nlm.nih.gov/geo/series/GSE122nnn/GSE122342/suppl/GSE122342%5Fmatrix%2Emtx%2Egz"        
+    download_url_data: "https://ftp.ncbi.nlm.nih.gov/geo/series/GSE122nnn/GSE122342/suppl/GSE122342%5Fmatrix%2Emtx%2Egz"        
     download_url_meta:
-        matrix:
-        genes: "ftp://ftp.ncbi.nlm.nih.gov/geo/series/GSE122nnn/GSE122342/suppl/GSE122342%5Fgenes%2Etsv%2Egz"
-        barcodes: "ftp://ftp.ncbi.nlm.nih.gov/geo/series/GSE122nnn/GSE122342/suppl/GSE122342%5Fbarcodes%2Etsv%2Egz"
-        cell_clusters: "https://data.mendeley.com/public-files/datasets/wgmfxds99c/files/7d25a827-c9e3-442d-af4a-e4cd997addd6/file_downloaded"
-        GSEA_enrichment: "https://data.mendeley.com/public-files/datasets/wgmfxds99c/files/975e9be2-d999-42e9-b311-ebdf182f296e/file_downloaded"
+        - "https://ftp.ncbi.nlm.nih.gov/geo/series/GSE122nnn/GSE122342/suppl/GSE122342%5Fgenes%2Etsv%2Egz"
+        - "https://ftp.ncbi.nlm.nih.gov/geo/series/GSE122nnn/GSE122342/suppl/GSE122342%5Fbarcodes%2Etsv%2Egz"
+        - "https://data.mendeley.com/public-files/datasets/wgmfxds99c/files/7d25a827-c9e3-442d-af4a-e4cd997addd6/file_downloaded"
+        - "https://data.mendeley.com/public-files/datasets/wgmfxds99c/files/975e9be2-d999-42e9-b311-ebdf182f296e/file_downloaded"
     primary_data: True
     year: 2019
 layers:
@@ -29,7 +23,7 @@ layers:
     layer_unspliced_processed: 
     layer_velocity: 
 dataset_or_feature_wise:
-    feature_reference: "Homo_sapiens.GRCh37.74"
+    feature_reference: "Homo_sapiens.GRCh37.82"
     feature_reference_var_key: 
     feature_type: "rna"
     feature_type_var_key: 
@@ -47,7 +41,7 @@ dataset_or_observation_wise:
     cell_type: 
     cell_type_obs_key: "Annotation"
     development_stage: 
-    development_stage_obs_key: "organoid_age_days"
+    development_stage_obs_key: "Time"
     disease: "healthy"
     disease_obs_key: 
     ethnicity: 

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2018_12_015/homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiang_001.yaml
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2018_12_015/homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiang_001.yaml
@@ -1,0 +1,99 @@
+dataset_structure:
+    dataset_index: 1
+    sample_fns:
+        - "matrix"
+        - "genes"
+        - "barcodes"
+        - "cell_clusters"
+        - "GSEA_enrichment"
+dataset_wise:
+    author: "Xiang, Yangfei"
+    default_embedding: 
+    doi_preprint: 
+    doi_journal: "10.1016/j.stem.2018.12.015"
+    download_url_data: "ftp://ftp.ncbi.nlm.nih.gov/geo/series/GSE122nnn/GSE122342/suppl/GSE122342%5Fmatrix%2Emtx%2Egz"        
+    download_url_meta:
+        matrix:
+        genes: "ftp://ftp.ncbi.nlm.nih.gov/geo/series/GSE122nnn/GSE122342/suppl/GSE122342%5Fgenes%2Etsv%2Egz"
+        barcodes: "ftp://ftp.ncbi.nlm.nih.gov/geo/series/GSE122nnn/GSE122342/suppl/GSE122342%5Fbarcodes%2Etsv%2Egz"
+        cell_clusters: "https://data.mendeley.com/public-files/datasets/wgmfxds99c/files/7d25a827-c9e3-442d-af4a-e4cd997addd6/file_downloaded"
+        GSEA_enrichment: "https://data.mendeley.com/public-files/datasets/wgmfxds99c/files/975e9be2-d999-42e9-b311-ebdf182f296e/file_downloaded"
+    primary_data: True
+    year: 2019
+layers:
+    layer_counts: "X"
+    layer_processed: 
+    layer_spliced_counts: 
+    layer_spliced_processed: 
+    layer_unspliced_counts: 
+    layer_unspliced_processed: 
+    layer_velocity: 
+dataset_or_feature_wise:
+    feature_reference: "Homo_sapiens.GRCh37.74"
+    feature_reference_var_key: 
+    feature_type: "rna"
+    feature_type_var_key: 
+dataset_or_observation_wise:
+    assay_sc: "10x 3' v1"
+    assay_sc_obs_key: 
+    assay_differentiation: "Xiang, 2017 (doi: 10.1016/j.stem.2017.07.007)"
+    assay_differentiation_obs_key: 
+    assay_type_differentiation: "guided"
+    assay_type_differentiation_obs_key: 
+    bio_sample:
+    bio_sample_obs_key: "Time"
+    cell_line: "HES-3 NKX2.1GFP/w"
+    cell_line_obs_key: 
+    cell_type: 
+    cell_type_obs_key: "Annotation"
+    development_stage: 
+    development_stage_obs_key: "organoid_age_days"
+    disease: "healthy"
+    disease_obs_key: 
+    ethnicity: 
+    ethnicity_obs_key: 
+    gm:
+    gm_obs_key:
+    individual:
+    individual_obs_key: 
+    organ: "dorsal plus ventral thalamus"
+    organ_obs_key: 
+    organism: "Homo sapiens"
+    organism_obs_key: 
+    sample_source: "3d_culture"
+    sample_source_obs_key: 
+    sex: "female"
+    sex_obs_key: 
+    source_doi:
+    source_doi_obs_key:
+    state_exact:
+    state_exact_obs_key:
+    suspension_type: "cell"
+    suspension_type_obs_key: 
+    tech_sample:
+    tech_sample_obs_key: 
+    treatment:
+    treatment_obs_key:
+feature_wise:
+    feature_id_var_key: "index"
+    feature_symbol_var_key: "gene_id"
+observation_wise:
+    spatial_x_coord_obs_key: 
+    spatial_y_coord_obs_key: 
+    spatial_z_coord_obs_key: 
+    vdj_vj_1_obs_key_prefix: 
+    vdj_vj_2_obs_key_prefix: 
+    vdj_vdj_1_obs_key_prefix: 
+    vdj_vdj_2_obs_key_prefix: 
+    vdj_c_call_obs_key_suffix: 
+    vdj_consensus_count_obs_key_suffix: 
+    vdj_d_call_obs_key_suffix: 
+    vdj_duplicate_count_obs_key_suffix: 
+    vdj_j_call_obs_key_suffix: 
+    vdj_junction_obs_key_suffix: 
+    vdj_junction_aa_obs_key_suffix: 
+    vdj_locus_obs_key_suffix: 
+    vdj_productive_obs_key_suffix: 
+    vdj_v_call_obs_key_suffix: 
+meta:
+    version: "1.2"

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2018_12_015/homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiang_001_cell_type.tsv
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2018_12_015/homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiang_001_cell_type.tsv
@@ -1,0 +1,11 @@
+source	target	target_id
+AS	astrocyte	CL:0000127
+BRC	neural cell	CL:0002319
+CBC	ciliated cell	CL:0000064
+GPC	radial glial cell	CL:0000681
+Immature neuron	neuron	CL:0000540
+Intermediate	neuroepithelial stem cell	CL:0002259
+Mature neuron	neuron	CL:0000540
+NPC	neural progenitor cell	CL:0011020
+PGG	glial cell	CL:0000125
+UPRC	neural cell	CL:0002319

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2018_12_015/homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiang_001_development_stage.tsv
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2018_12_015/homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiang_001_development_stage.tsv
@@ -1,0 +1,3 @@
+source	target	target_id
+34	Carnegie stage 15	HsapDv:0000022
+89	13th week post-fertilization human stage	HsapDv:0000050

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2018_12_015/homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiang_001_development_stage.tsv
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2018_12_015/homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiang_001_development_stage.tsv
@@ -1,3 +1,3 @@
 source	target	target_id
-34	Carnegie stage 15	HsapDv:0000022
-89	13th week post-fertilization human stage	HsapDv:0000050
+early	Carnegie stage 15	HsapDv:0000022
+late	13th week post-fertilization human stage	HsapDv:0000050


### PR DESCRIPTION
Installed version v0.3.12+52.gf105a1f of sfaira is newer than the latest release
0.3.12! You are running a nightly version and features may break!
Run sfaira upgrade to get the latest version.
Running loader lint checks ━━━━━━━━━━━━━              1 of 2 _validate_namespace
Running loader lint checks ━━━━━━━━         1 of 2 _validate_namespace          
Running yaml lint checks   ━━━━━━━━━━━━━━━━ 2 of 2 _validate_required_attributes

────────────────────────────────  LINT RESULTS ─────────────────────────────────

     [[✔]]    3 tests passed
     [[!]]    0 tests had warnings
     [[✗]]    0 tests failed

────────────────────────────── [[✔]] Tests Passed ──────────────────────────────
╭──────────────────────────────────────────────────────────────────────────────╮
│ Result: Passed required data loader load() namespace checks.                 │
│ Result: Passed required data loader section checks.                          │
│ Result: Passed required meta data checks.                                    │
╰──────────────────────────────────────────────────────────────────────────────╯
Conflicts are not automatically resolved.
In case of coflicts, please go back to https://www.ebi.ac.uk/ols/ontologies/cl 
and add the correct cell ontology class name into the .tsv "target" column.
WARNING:nxontology.imports:Cannot add edge: MmusDv:0000000 --> MmusDv:0000038 (mouse life cycle stage --> infant stage): node does not exist in graph: MmusDv:0000038
WARNING:nxontology.imports:Cannot add edge: MmusDv:0000000 --> MmusDv:0000043 (mouse life cycle stage --> immature stage): node does not exist in graph: MmusDv:0000043
WARNING:nxontology.imports:Cannot add edge: MmusDv:0000000 --> MmusDv:0000044 (mouse life cycle stage --> 1-7 days): node does not exist in graph: MmusDv:0000044
WARNING:nxontology.imports:Cannot add edge: MmusDv:0000000 --> MmusDv:0000096 (mouse life cycle stage --> early immature stage): node does not exist in graph: MmusDv:0000096
/lustre/groups/ml01/code/irena.sliskovic/sfaira/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2018_12_015/homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiang_001.py:36: FutureWarning: X.dtype being converted to np.float32 from int64. In the next version of anndata (0.9) conversion will not be automatic. Pass dtype explicitly to avoid this warning. Pass `AnnData(X, dtype=X.dtype, ...)` to get the future behavour.
  adata = ad.AnnData(
/lustre/groups/ml01/code/irena.sliskovic/sfaira/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2018_12_015/homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiang_001.py:36: FutureWarning: X.dtype being converted to np.float32 from int64. In the next version of anndata (0.9) conversion will not be automatic. Pass dtype explicitly to avoid this warning. Pass `AnnData(X, dtype=X.dtype, ...)` to get the future behavour.
  adata = ad.AnnData(
/lustre/groups/ml01/code/irena.sliskovic/sfaira/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2018_12_015/homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiang_001.py:36: FutureWarning: X.dtype being converted to np.float32 from int64. In the next version of anndata (0.9) conversion will not be automatic. Pass dtype explicitly to avoid this warning. Pass `AnnData(X, dtype=X.dtype, ...)` to get the future behavour.
  adata = ad.AnnData(
/lustre/groups/ml01/code/irena.sliskovic/sfaira/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2018_12_015/homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiang_001.py:36: FutureWarning: X.dtype being converted to np.float32 from int64. In the next version of anndata (0.9) conversion will not be automatic. Pass dtype explicitly to avoid this warning. Pass `AnnData(X, dtype=X.dtype, ...)` to get the future behavour.
  adata = ad.AnnData(
/lustre/groups/ml01/code/irena.sliskovic/sfaira/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2018_12_015/homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiang_001.py:36: FutureWarning: X.dtype being converted to np.float32 from int64. In the next version of anndata (0.9) conversion will not be automatic. Pass dtype explicitly to avoid this warning. Pass `AnnData(X, dtype=X.dtype, ...)` to get the future behavour.
  adata = ad.AnnData(
transformed feature space on homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiangyangfei_001_d10_1016_j_stem_2018_12_015: 
log10 total counts 8.05 to 8.05, non-zero features 24836 to 23849
transformed feature space on homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiangyangfei_002_d10_1016_j_stem_2018_12_015: 
log10 total counts 8.05 to 8.05, non-zero features 24836 to 23849
transformed feature space on homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiangyangfei_003_d10_1016_j_stem_2018_12_015: 
log10 total counts 8.05 to 8.05, non-zero features 24836 to 23849
transformed feature space on homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiangyangfei_004_d10_1016_j_stem_2018_12_015: 
log10 total counts 8.05 to 8.05, non-zero features 24836 to 23849
transformed feature space on homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiangyangfei_005_d10_1016_j_stem_2018_12_015: 
log10 total counts 8.05 to 8.05, non-zero features 24836 to 23849
Completed testing of data loader, the data loader is now ready for use.
Sfaira butler: "You data loader is finished!"
               "Proceed to phase 4 (publish) or use data loader."
               "Copy the following lines as a post into the pull request:"
=========================
Data loader test passed:
    - 
homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiangyangfei_001_d10_1016_j_st
em_2018_12_015
    - 
homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiangyangfei_002_d10_1016_j_st
em_2018_12_015
    - 
homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiangyangfei_003_d10_1016_j_st
em_2018_12_015
    - 
homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiangyangfei_004_d10_1016_j_st
em_2018_12_015
    - 
homosapiens_dorsalplusventralthalamus_2019_10x3v1_xiangyangfei_005_d10_1016_j_st
em_2018_12_015
=========================
