### PR TITLE
data/d10_1016_j_stem_2019_08_002

### DIFF
--- a/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2019_08_002/__init__.py
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2019_08_002/__init__.py
@@ -1,0 +1,1 @@
+FILE_PATH = __file__

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2019_08_002/homosapiens_cortex_2019_10x3v2_trujillo_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2019_08_002/homosapiens_cortex_2019_10x3v2_trujillo_001.py
@@ -16,7 +16,6 @@ def load(data_dir, **kwargs):
     barcodes = []
     genes = []
     matrix = []
-    sample = []
 
     with tarfile.open(fn) as tar:
         for member in tar.getmembers():
@@ -35,7 +34,7 @@ def load(data_dir, **kwargs):
                     bar['organoid_age_days'] = "300"
                 barcodes.append(bar)
             elif re.search('genes', temp):
-                gen = pd.read_csv(tar.extractfile(member), delimiter='\t', compression='gzip', index_col=0, header = None, names=["ensembl_gene_id", "gene_id"])
+                gen = pd.read_csv(tar.extractfile(member), delimiter='\t', compression='gzip', index_col=0, header=None, names=["ensembl_gene_id", "gene_id"])
                 genes.append(gen)
             else:
                 fn_matrix = tar.extractfile(member)

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2019_08_002/homosapiens_cortex_2019_10x3v2_trujillo_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2019_08_002/homosapiens_cortex_2019_10x3v2_trujillo_001.py
@@ -1,0 +1,56 @@
+import numpy as np
+import pandas as pd
+import tarfile
+import anndata as ad
+import scipy.sparse
+import os
+import scanpy as sc
+import re
+from tempfile import TemporaryDirectory
+import shutil
+import gzip
+
+
+def load(data_dir, **kwargs):
+    fn = os.path.join(data_dir, "GSE130238_RAW.tar")
+    barcodes = []
+    genes = []
+    matrix = []
+    sample = []
+
+    with tarfile.open(fn) as tar:
+        for member in tar.getmembers():
+            temp = member.name
+            if re.search('barcodes', temp):
+                bar = pd.read_csv(tar.extractfile(member), delimiter='\t', compression="gzip", header=None, index_col=0)
+                bar.index.name = None
+                bar['time'] = member.name.split("_")[1]
+                if member.name.split("_")[1] == "1M":
+                    bar['organoid_age_days'] = "30"
+                elif member.name.split("_")[1] == "3M":
+                    bar['organoid_age_days'] = "90"
+                elif member.name.split("_")[1] == "6M":
+                    bar['organoid_age_days'] = "180"
+                else:
+                    bar['organoid_age_days'] = "300"
+                barcodes.append(bar)
+            elif re.search('genes', temp):
+                gen = pd.read_csv(tar.extractfile(member), delimiter='\t', compression='gzip', index_col=0, header = None, names=["ensembl_gene_id", "gene_id"])
+                genes.append(gen)
+            else:
+                fn_matrix = tar.extractfile(member)
+                uncompressed_file_type = "mtx"
+                with TemporaryDirectory() as tmpdir:
+                    tmppth = tmpdir + f"/decompressed.{uncompressed_file_type}"
+                    with gzip.open(fn_matrix, "rb") as input_f, open(tmppth, "wb") as output_f:
+                        shutil.copyfileobj(input_f, output_f)
+                    mat = scipy.io.mmread(tmppth)
+                matrix.append(mat.T)
+
+    adatas = []
+    for i in range(len(matrix)):
+        temp = ad.AnnData(X=matrix[i], obs=barcodes[i], var=genes[i])
+        adatas.append(temp)
+    adata = ad.concat(adatas, merge='first')
+
+    return adata

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2019_08_002/homosapiens_cortex_2019_10x3v2_trujillo_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2019_08_002/homosapiens_cortex_2019_10x3v2_trujillo_001.py
@@ -2,54 +2,26 @@ import numpy as np
 import pandas as pd
 import tarfile
 import anndata as ad
-import scipy.sparse
+import scipy.io
 import os
-import scanpy as sc
-import re
-from tempfile import TemporaryDirectory
-import shutil
 import gzip
 
 
-def load(data_dir, **kwargs):
+def load(data_dir, sample_fn, **kwargs):
+    age_dict = {
+        "1M": "30",
+        "3M": "90",
+        "6M": "180",
+        "10M": "300",
+    }
     fn = os.path.join(data_dir, "GSE130238_RAW.tar")
-    barcodes = []
-    genes = []
-    matrix = []
-
     with tarfile.open(fn) as tar:
-        for member in tar.getmembers():
-            temp = member.name
-            if re.search('barcodes', temp):
-                bar = pd.read_csv(tar.extractfile(member), delimiter='\t', compression="gzip", header=None, index_col=0)
-                bar.index.name = None
-                bar['time'] = member.name.split("_")[1]
-                if member.name.split("_")[1] == "1M":
-                    bar['organoid_age_days'] = "30"
-                elif member.name.split("_")[1] == "3M":
-                    bar['organoid_age_days'] = "90"
-                elif member.name.split("_")[1] == "6M":
-                    bar['organoid_age_days'] = "180"
-                else:
-                    bar['organoid_age_days'] = "300"
-                barcodes.append(bar)
-            elif re.search('genes', temp):
-                gen = pd.read_csv(tar.extractfile(member), delimiter='\t', compression='gzip', index_col=0, header=None, names=["ensembl_gene_id", "gene_id"])
-                genes.append(gen)
-            else:
-                fn_matrix = tar.extractfile(member)
-                uncompressed_file_type = "mtx"
-                with TemporaryDirectory() as tmpdir:
-                    tmppth = tmpdir + f"/decompressed.{uncompressed_file_type}"
-                    with gzip.open(fn_matrix, "rb") as input_f, open(tmppth, "wb") as output_f:
-                        shutil.copyfileobj(input_f, output_f)
-                    mat = scipy.io.mmread(tmppth)
-                matrix.append(mat.T)
-
-    adatas = []
-    for i in range(len(matrix)):
-        temp = ad.AnnData(X=matrix[i], obs=barcodes[i], var=genes[i])
-        adatas.append(temp)
-    adata = ad.concat(adatas, merge='first')
-
+        with gzip.open(tar.extractfile(f"{sample_fn}_cortical_organoids_matrix.mtx.gz"), "rb") as mm:
+            x = scipy.io.mmread(mm).T.tocsr().astype(np.float32)
+        obs = pd.read_csv(tar.extractfile(f"{sample_fn}_cortical_organoids_barcodes.tsv.gz"),
+                          delimiter='\t', compression="gzip", header=None, index_col=0, names=[None])
+        obs['organoid_age_days'] = age_dict[sample_fn.split("_")[1]]
+        var = pd.read_csv(tar.extractfile(f"{sample_fn}_cortical_organoids_genes.tsv.gz"),
+                          delimiter='\t', compression='gzip', index_col=0, header=None, names=[None, "gene_id"])
+    adata = ad.AnnData(X=x, obs=obs, var=var)
     return adata

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2019_08_002/homosapiens_cortex_2019_10x3v2_trujillo_001.yaml
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2019_08_002/homosapiens_cortex_2019_10x3v2_trujillo_001.yaml
@@ -6,7 +6,7 @@ dataset_wise:
     default_embedding: 
     doi_preprint: 
     doi_journal: "10.1016/j.stem.2019.08.002"
-    download_url_data: "ftp://ftp.ncbi.nlm.nih.gov/geo/series/GSE130nnn/GSE130238/suppl/GSE130238_RAW.tar"
+    download_url_data: "https://ftp.ncbi.nlm.nih.gov/geo/series/GSE130nnn/GSE130238/suppl/GSE130238_RAW.tar"
     download_url_meta: 
     primary_data: True
     year: 2019
@@ -28,7 +28,7 @@ dataset_or_observation_wise:
     assay_sc_obs_key: 
     assay_differentiation: "Pasca, 2015 (doi: 10.1038/nmeth.3415)"
     assay_differentiation_obs_key: 
-    assay_type_differentiation: "unguided"
+    assay_type_differentiation: "guided"
     assay_type_differentiation_obs_key: 
     bio_sample:
     bio_sample_obs_key: "time"

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2019_08_002/homosapiens_cortex_2019_10x3v2_trujillo_001.yaml
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2019_08_002/homosapiens_cortex_2019_10x3v2_trujillo_001.yaml
@@ -1,0 +1,89 @@
+dataset_structure:
+    dataset_index: 1
+    sample_fns:
+dataset_wise:
+    author: "Trujillo, Cleber"
+    default_embedding: 
+    doi_preprint: 
+    doi_journal: "10.1016/j.stem.2019.08.002"
+    download_url_data: "ftp://ftp.ncbi.nlm.nih.gov/geo/series/GSE130nnn/GSE130238/suppl/GSE130238_RAW.tar"
+    download_url_meta: 
+    primary_data: True
+    year: 2019
+layers:
+    layer_counts: "X"
+    layer_processed: 
+    layer_spliced_counts: 
+    layer_spliced_processed: 
+    layer_unspliced_counts: 
+    layer_unspliced_processed: 
+    layer_velocity: 
+dataset_or_feature_wise:
+    feature_reference: "Homo_sapiens.GRCh38.84"
+    feature_reference_var_key: 
+    feature_type: "rna"
+    feature_type_var_key: 
+dataset_or_observation_wise:
+    assay_sc: "10x 3' v2"
+    assay_sc_obs_key: 
+    assay_differentiation: "Pasca, 2015 (doi: 10.1038/nmeth.3415)"
+    assay_differentiation_obs_key: 
+    assay_type_differentiation: "unguided"
+    assay_type_differentiation_obs_key: 
+    bio_sample:
+    bio_sample_obs_key: "time"
+    cell_line: "WT - iPSC"
+    cell_line_obs_key: 
+    cell_type: 
+    cell_type_obs_key: 
+    development_stage: 
+    development_stage_obs_key: "organoid_age_days"
+    disease: "healthy"
+    disease_obs_key: 
+    ethnicity: 
+    ethnicity_obs_key: 
+    gm:
+    gm_obs_key:
+    individual:
+    individual_obs_key: 
+    organ: "forebrain"
+    organ_obs_key: 
+    organism: "Homo sapiens"
+    organism_obs_key: 
+    sample_source: "3d_culture"
+    sample_source_obs_key: 
+    sex: "male"
+    sex_obs_key: 
+    source_doi:
+    source_doi_obs_key:
+    state_exact:
+    state_exact_obs_key:
+    suspension_type: "cell"
+    suspension_type_obs_key: 
+    tech_sample:
+    tech_sample_obs_key: 
+    treatment:
+    treatment_obs_key:
+feature_wise:
+    feature_id_var_key: "index"
+    feature_symbol_var_key: "gene_id"
+observation_wise:
+    spatial_x_coord_obs_key: 
+    spatial_y_coord_obs_key: 
+    spatial_z_coord_obs_key: 
+    vdj_vj_1_obs_key_prefix: 
+    vdj_vj_2_obs_key_prefix: 
+    vdj_vdj_1_obs_key_prefix: 
+    vdj_vdj_2_obs_key_prefix: 
+    vdj_c_call_obs_key_suffix: 
+    vdj_consensus_count_obs_key_suffix: 
+    vdj_d_call_obs_key_suffix: 
+    vdj_duplicate_count_obs_key_suffix: 
+    vdj_j_call_obs_key_suffix: 
+    vdj_junction_obs_key_suffix: 
+    vdj_junction_aa_obs_key_suffix: 
+    vdj_locus_obs_key_suffix: 
+    vdj_productive_obs_key_suffix: 
+    vdj_v_call_obs_key_suffix: 
+meta:
+    version: "1.2"

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2019_08_002/homosapiens_cortex_2019_10x3v2_trujillo_001.yaml
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2019_08_002/homosapiens_cortex_2019_10x3v2_trujillo_001.yaml
@@ -1,6 +1,18 @@
 dataset_structure:
     dataset_index: 1
     sample_fns:
+        - "GSM3734294_1M"
+        - "GSM3734294_1M"
+        - "GSM3734294_1M"
+        - "GSM3734295_3M"
+        - "GSM3734295_3M"
+        - "GSM3734295_3M"
+        - "GSM3734296_6M"
+        - "GSM3734296_6M"
+        - "GSM3734296_6M"
+        - "GSM3734297_10M"
+        - "GSM3734297_10M"
+        - "GSM3734297_10M"
 dataset_wise:
     author: "Trujillo, Cleber"
     default_embedding: 
@@ -31,13 +43,25 @@ dataset_or_observation_wise:
     assay_type_differentiation: "guided"
     assay_type_differentiation_obs_key: 
     bio_sample:
-    bio_sample_obs_key: "time"
-    cell_line: "WT - iPSC"
+    bio_sample_obs_key:
+    cell_line:
     cell_line_obs_key: 
     cell_type: 
     cell_type_obs_key: 
-    development_stage: 
-    development_stage_obs_key: "organoid_age_days"
+    development_stage:
+        GSM3734294_1M: "Carnegie stage 13"
+        GSM3734294_1M: "Carnegie stage 13"
+        GSM3734294_1M: "Carnegie stage 13"
+        GSM3734295_3M: "13th week post-fertilization human stage"
+        GSM3734295_3M: "13th week post-fertilization human stage"
+        GSM3734295_3M: "13th week post-fertilization human stage"
+        GSM3734296_6M: "26th week post-fertilization human stage"
+        GSM3734296_6M: "26th week post-fertilization human stage"
+        GSM3734296_6M: "26th week post-fertilization human stage"
+        GSM3734297_10M: "2-month-old human stage"
+        GSM3734297_10M: "2-month-old human stage"
+        GSM3734297_10M: "2-month-old human stage"
+    development_stage_obs_key:
     disease: "healthy"
     disease_obs_key: 
     ethnicity: 
@@ -46,7 +70,7 @@ dataset_or_observation_wise:
     gm_obs_key:
     individual:
     individual_obs_key: 
-    organ: "forebrain"  # I think some of the older organoids should have the annotation cortex, but in the shared table the mentioned organ was only forebrain
+    organ: "cerebral cortex"
     organ_obs_key: 
     organism: "Homo sapiens"
     organism_obs_key: 

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2019_08_002/homosapiens_cortex_2019_10x3v2_trujillo_001.yaml
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2019_08_002/homosapiens_cortex_2019_10x3v2_trujillo_001.yaml
@@ -46,7 +46,7 @@ dataset_or_observation_wise:
     gm_obs_key:
     individual:
     individual_obs_key: 
-    organ: "forebrain"
+    organ: "forebrain"  # I think some of the older organoids should have the annotation cortex, but in the shared table the mentioned organ was only forebrain
     organ_obs_key: 
     organism: "Homo sapiens"
     organism_obs_key: 

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2019_08_002/homosapiens_cortex_2019_10x3v2_trujillo_001_development_stage.tsv
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2019_08_002/homosapiens_cortex_2019_10x3v2_trujillo_001_development_stage.tsv
@@ -1,5 +1,0 @@
-source	target	target_id
-180	26th week post-fertilization human stage	HsapDv:0000063
-30	Carnegie stage 13	HsapDv:0000020
-300	2-month-old human stage	HsapDv:0000175
-90	13th week post-fertilization human stage	HsapDv:0000050

--- a/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2019_08_002/homosapiens_cortex_2019_10x3v2_trujillo_001_development_stage.tsv
+++ b/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2019_08_002/homosapiens_cortex_2019_10x3v2_trujillo_001_development_stage.tsv
@@ -1,0 +1,5 @@
+source	target	target_id
+180	26th week post-fertilization human stage	HsapDv:0000063
+30	Carnegie stage 13	HsapDv:0000020
+300	2-month-old human stage	HsapDv:0000175
+90	13th week post-fertilization human stage	HsapDv:0000050


### PR DESCRIPTION
Run sfaira --help for an overview of all commands

Installed version v0.3.12+52.gf105a1f of sfaira is newer than the latest release 0.3.12! You are running a nightly version and features may break!
Run sfaira upgrade to get the latest version.
Running loader lint checks ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╸━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1 of 2 _validate_namespace
Running loader lint checks ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╸━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1 of 2 _validate_namespace          
Running yaml lint checks   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2 of 2 _validate_required_attributes

──────────────────────────────────────────────────────────────────────────────────────────────  LINT RESULTS ──────────────────────────────────────────────────────────────────────────────────────────────

     [[✔]]    3 tests passed
     [[!]]    0 tests had warnings
     [[✗]]    0 tests failed

─────────────────────────────────────────────────────────────────────────────────────────── [[✔]] Tests Passed ────────────────────────────────────────────────────────────────────────────────────────────
╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Result: Passed required data loader load() namespace checks.                                                                                                                                            │
│ Result: Passed required data loader section checks.                                                                                                                                                     │
│ Result: Passed required meta data checks.                                                                                                                                                               │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
Conflicts are not automatically resolved.
In case of coflicts, please go back to https://www.ebi.ac.uk/ols/ontologies/cl and add the correct cell ontology class name into the .tsv "target" column.
WARNING:nxontology.imports:Cannot add edge: MmusDv:0000000 --> MmusDv:0000038 (mouse life cycle stage --> infant stage): node does not exist in graph: MmusDv:0000038
WARNING:nxontology.imports:Cannot add edge: MmusDv:0000000 --> MmusDv:0000043 (mouse life cycle stage --> immature stage): node does not exist in graph: MmusDv:0000043
WARNING:nxontology.imports:Cannot add edge: MmusDv:0000000 --> MmusDv:0000044 (mouse life cycle stage --> 1-7 days): node does not exist in graph: MmusDv:0000044
WARNING:nxontology.imports:Cannot add edge: MmusDv:0000000 --> MmusDv:0000096 (mouse life cycle stage --> early immature stage): node does not exist in graph: MmusDv:0000096
/lustre/groups/ml01/code/irena.sliskovic/sfaira/sfaira/data/dataloaders/loaders/d10_1016_j_stem_2019_08_002/homosapiens_cortex_2019_10x3v2_trujillo_001.py:52: FutureWarning: X.dtype being converted to np.float32 from int64. In the next version of anndata (0.9) conversion will not be automatic. Pass dtype explicitly to avoid this warning. Pass `AnnData(X, dtype=X.dtype, ...)` to get the future behavour.
  temp = ad.AnnData(X=matrix[i], obs=barcodes[i], var=genes[i])
/home/icb/irena.sliskovic/miniconda3/envs/sfaira/lib/python3.10/site-packages/anndata/_core/anndata.py:1828: UserWarning: Observation names are not unique. To make them unique, call `.obs_names_make_unique`.
  utils.warn_names_duplicates("obs")
transformed feature space on homosapiens_forebrain_2019_10x3v2_trujillocleber_001_d10_1016_j_stem_2019_08_002: 
log10 total counts 7.94 to 7.94, non-zero features 24762 to 24390
Completed testing of data loader, the data loader is now ready for use.
Sfaira butler: "You data loader is finished!"
               "Proceed to phase 4 (publish) or use data loader."
               "Copy the following lines as a post into the pull request:"
=========================
Data loader test passed:
    - homosapiens_forebrain_2019_10x3v2_trujillocleber_001_d10_1016_j_stem_2019_08_002
=========================
