### PR TITLE
data/d10_1038_s41592_018_0255_0

### DIFF
--- a/sfaira/data/dataloaders/loaders/d10_1038_s41592_018_0255_0/__init__.py
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41592_018_0255_0/__init__.py
@@ -1,0 +1,1 @@
+FILE_PATH = __file__

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41592_018_0255_0/homosapiens_pallium_2019_bdrhapsodywholetranscriptomeanalysis_yoon_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41592_018_0255_0/homosapiens_pallium_2019_bdrhapsodywholetranscriptomeanalysis_yoon_001.py
@@ -4,25 +4,15 @@ import tarfile
 import anndata as ad
 import scipy.sparse
 import os
-import scanpy as sc
 
 
-def load(data_dir, **kwargs):
+def load(data_dir, sample_fn, **kwargs):
     fn = os.path.join(data_dir, "GSE107771_RAW.tar")
-    dfs = []
-    obs = []
-    with tarfile.open(fn) as tar:
-        for member in tar.getmembers():
-            d = pd.read_csv(tar.extractfile(member), compression="gzip", header=0, index_col=0)
-            for i in range(d.shape[0]):
-                temp = member.name.split("_")[1] + '_' + member.name.split("_")[2] + member.name.split("_")[3]
-                obs.append(temp)
-            dfs.append(d)
-
-    adata = ad.AnnData(
-        X=scipy.sparse.csr_matrix(np.vstack((dfs[0], dfs[1], dfs[2]))),
-        obs=pd.DataFrame({"sample": obs}),
-        var=pd.DataFrame(index=dfs[0].columns.values))
-    adata.obs['organoid_age_days'] = np.repeat(105, len(adata.obs))
+    with tarfile.open(fn, "r") as tar:
+        df = pd.read_csv(tar.extractfile(f"{sample_fn}_MolsPerCell.csv.gz"), compression="gzip", index_col=0)
+        adata = ad.AnnData(X=scipy.sparse.csr_matrix(df, dtype=np.float32),
+                           var=pd.DataFrame(index=df.columns),
+                           obs=pd.DataFrame(index=df.index.tolist()))
+    adata.obs['organoid_age_days'] = "105"
 
     return adata

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41592_018_0255_0/homosapiens_pallium_2019_bdrhapsodywholetranscriptomeanalysis_yoon_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41592_018_0255_0/homosapiens_pallium_2019_bdrhapsodywholetranscriptomeanalysis_yoon_001.py
@@ -1,0 +1,28 @@
+import numpy as np
+import pandas as pd
+import tarfile
+import anndata as ad
+import scipy.sparse
+import os
+import scanpy as sc
+
+
+def load(data_dir, **kwargs):
+    fn = os.path.join(data_dir, "GSE107771_RAW.tar")
+    dfs = []
+    obs = []
+    with tarfile.open(fn) as tar:
+        for member in tar.getmembers():
+            d = pd.read_csv(tar.extractfile(member), compression="gzip", header=0, index_col=0)
+            for i in range(d.shape[0]):
+                temp = member.name.split("_")[1] + '_' + member.name.split("_")[2] + member.name.split("_")[3]
+                obs.append(temp)
+            dfs.append(d)
+
+    adata = ad.AnnData(
+        X=scipy.sparse.csr_matrix(np.vstack((dfs[0], dfs[1], dfs[2]))),
+        obs=pd.DataFrame({"sample": obs}),
+        var=pd.DataFrame(index=dfs[0].columns.values))
+    adata.obs['organoid_age_days'] = np.repeat(105, len(adata.obs))
+
+    return adata

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41592_018_0255_0/homosapiens_pallium_2019_bdrhapsodywholetranscriptomeanalysis_yoon_001.yaml
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41592_018_0255_0/homosapiens_pallium_2019_bdrhapsodywholetranscriptomeanalysis_yoon_001.yaml
@@ -1,0 +1,89 @@
+dataset_structure:
+    dataset_index: 1
+    sample_fns:
+dataset_wise:
+    author: "Yoon, Se-Jin"
+    default_embedding: 
+    doi_preprint: 
+    doi_journal: "10.1038/s41592-018-0255-0"
+    download_url_data: "https://ftp.ncbi.nlm.nih.gov/geo/series/GSE107nnn/GSE107771/suppl/GSE107771_RAW.tar"
+    download_url_meta: 
+    primary_data: True
+    year: 2019
+layers:
+    layer_counts: "X"
+    layer_processed: 
+    layer_spliced_counts: 
+    layer_spliced_processed: 
+    layer_unspliced_counts: 
+    layer_unspliced_processed: 
+    layer_velocity: 
+dataset_or_feature_wise:
+    feature_reference: "Homo_sapiens.GRCh37.74"
+    feature_reference_var_key: 
+    feature_type: "rna"
+    feature_type_var_key: 
+dataset_or_observation_wise:
+    assay_sc: "BD Rhapsody Whole Transcriptome Analysis"
+    assay_sc_obs_key: 
+    assay_differentiation: "Yoon and Pasca, 2018 (doi: 10.1038/protex.2018.123)"
+    assay_differentiation_obs_key: 
+    assay_type_differentiation: "guided"
+    assay_type_differentiation_obs_key: 
+    bio_sample:
+    bio_sample_obs_key: "sample"
+    cell_line: 
+    cell_line_obs_key: #"sample" hCS_FF1 is custom_C-6.1; hCS_FF2 is custom_C-6.2; hCS_FF3 is custom_C-7
+    cell_type: 
+    cell_type_obs_key: 
+    development_stage: "15th week post-fertilization human stage"
+    development_stage_obs_key: 
+    disease: "healthy"
+    disease_obs_key: 
+    ethnicity: 
+    ethnicity_obs_key: 
+    gm:
+    gm_obs_key:
+    individual:
+    individual_obs_key: 
+    organ: "pallium"
+    organ_obs_key: 
+    organism: "Homo sapiens"
+    organism_obs_key: 
+    sample_source: "3d_culture"
+    sample_source_obs_key: 
+    sex: 
+    sex_obs_key: #unknown, should be from different donors
+    source_doi:
+    source_doi_obs_key:
+    state_exact:
+    state_exact_obs_key:
+    suspension_type: "cell"
+    suspension_type_obs_key: 
+    tech_sample:
+    tech_sample_obs_key: 
+    treatment:
+    treatment_obs_key:
+feature_wise:
+    feature_id_var_key: 
+    feature_symbol_var_key: "index"
+observation_wise:
+    spatial_x_coord_obs_key: 
+    spatial_y_coord_obs_key: 
+    spatial_z_coord_obs_key: 
+    vdj_vj_1_obs_key_prefix: 
+    vdj_vj_2_obs_key_prefix: 
+    vdj_vdj_1_obs_key_prefix: 
+    vdj_vdj_2_obs_key_prefix: 
+    vdj_c_call_obs_key_suffix: 
+    vdj_consensus_count_obs_key_suffix: 
+    vdj_d_call_obs_key_suffix: 
+    vdj_duplicate_count_obs_key_suffix: 
+    vdj_j_call_obs_key_suffix: 
+    vdj_junction_obs_key_suffix: 
+    vdj_junction_aa_obs_key_suffix: 
+    vdj_locus_obs_key_suffix: 
+    vdj_productive_obs_key_suffix: 
+    vdj_v_call_obs_key_suffix: 
+meta:
+    version: "1.2"

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41592_018_0255_0/homosapiens_pallium_2019_bdrhapsodywholetranscriptomeanalysis_yoon_001.yaml
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41592_018_0255_0/homosapiens_pallium_2019_bdrhapsodywholetranscriptomeanalysis_yoon_001.yaml
@@ -1,6 +1,9 @@
 dataset_structure:
     dataset_index: 1
     sample_fns:
+        - "GSM2878890_hCS_FF_1"
+        - "GSM2878891_hCS_FF_2"
+        - "GSM2878892_hCS_FF_3"
 dataset_wise:
     author: "Yoon, Se-Jin"
     default_embedding: 
@@ -31,9 +34,12 @@ dataset_or_observation_wise:
     assay_type_differentiation: "guided"
     assay_type_differentiation_obs_key: 
     bio_sample:
-    bio_sample_obs_key: "sample"
-    cell_line: 
-    cell_line_obs_key: #"sample" hCS_FF1 is custom_C-6.1; hCS_FF2 is custom_C-6.2; hCS_FF3 is custom_C-7
+    bio_sample_obs_key:
+    cell_line:
+        GSM2878890_hCS_FF_1: "custom_C-6.1"
+        GSM2878891_hCS_FF_2: "custom_C-6.2"
+        GSM2878892_hCS_FF_3: "custom_C-7"
+    cell_line_obs_key:
     cell_type: 
     cell_type_obs_key: 
     development_stage: "15th week post-fertilization human stage"
@@ -53,7 +59,7 @@ dataset_or_observation_wise:
     sample_source: "3d_culture"
     sample_source_obs_key: 
     sex: 
-    sex_obs_key: #unknown, should be from different donors
+    sex_obs_key: # unknown, should be from different donors
     source_doi:
     source_doi_obs_key:
     state_exact:


### PR DESCRIPTION
Installed version v0.3.12+52.gf105a1f of sfaira is newer than the latest release 0.3.12! You are running a nightly version and features may break!
Run sfaira upgrade to get the latest version.
Running loader lint checks ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╸━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1 of 2 _validate_namespace
Running loader lint checks ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╸━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 1 of 2 _validate_namespace          
Running yaml lint checks   ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 2 of 2 _validate_required_attributes

──────────────────────────────────────────────────────────────────────────────────────────────  LINT RESULTS ──────────────────────────────────────────────────────────────────────────────────────────────

     [[✔]]    3 tests passed
     [[!]]    0 tests had warnings
     [[✗]]    0 tests failed

─────────────────────────────────────────────────────────────────────────────────────────── [[✔]] Tests Passed ────────────────────────────────────────────────────────────────────────────────────────────
╭─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
│ Result: Passed required data loader load() namespace checks.                                                                                                                                            │
│ Result: Passed required data loader section checks.                                                                                                                                                     │
│ Result: Passed required meta data checks.                                                                                                                                                               │
╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
Conflicts are not automatically resolved.
In case of coflicts, please go back to https://www.ebi.ac.uk/ols/ontologies/cl and add the correct cell ontology class name into the .tsv "target" column.
WARNING:nxontology.imports:Cannot add edge: MmusDv:0000000 --> MmusDv:0000038 (mouse life cycle stage --> infant stage): node does not exist in graph: MmusDv:0000038
WARNING:nxontology.imports:Cannot add edge: MmusDv:0000000 --> MmusDv:0000043 (mouse life cycle stage --> immature stage): node does not exist in graph: MmusDv:0000043
WARNING:nxontology.imports:Cannot add edge: MmusDv:0000000 --> MmusDv:0000044 (mouse life cycle stage --> 1-7 days): node does not exist in graph: MmusDv:0000044
WARNING:nxontology.imports:Cannot add edge: MmusDv:0000000 --> MmusDv:0000096 (mouse life cycle stage --> early immature stage): node does not exist in graph: MmusDv:0000096
/lustre/groups/ml01/code/irena.sliskovic/sfaira/sfaira/data/dataloaders/loaders/d10_1038_s41592_018_0255_0/homosapiens_pallium_2019_bdrhapsodywholetranscriptomeanalysis_yoon_001.py:22: FutureWarning: X.dtype being converted to np.float32 from int64. In the next version of anndata (0.9) conversion will not be automatic. Pass dtype explicitly to avoid this warning. Pass `AnnData(X, dtype=X.dtype, ...)` to get the future behavour.
  adata = ad.AnnData(
transformed feature space on homosapiens_pallium_2019_bdrhapsodywholetranscriptomeanalysis_yoonsejin_001_d10_1038_s41592_018_0255_0: 
log10 total counts 7.43 to 7.4, non-zero features 27187 to 18492
Completed testing of data loader, the data loader is now ready for use.
Sfaira butler: "You data loader is finished!"
               "Proceed to phase 4 (publish) or use data loader."
               "Copy the following lines as a post into the pull request:"
=========================
Data loader test passed:
    - homosapiens_pallium_2019_bdrhapsodywholetranscriptomeanalysis_yoonsejin_001_d10_1038_s41592_018_0255_0
=========================
