### PR TITLE
data/d10_1038_s41586_020_1962_0

### DIFF
--- a/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/__init__.py
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/__init__.py
@@ -1,0 +1,1 @@
+FILE_PATH = __file__

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001.py
@@ -1,0 +1,56 @@
+import numpy as np
+import pandas as pd
+import anndata as ad
+import scipy.sparse
+import os
+import scanpy as sc
+
+
+def load(data_dir, **kwargs):
+    dic = {
+        "sample": ["donor", "organoid_age_days", "protocol"],
+        "H1SWeek3": ["H1", "21", "Least Direct [L]"],  # male
+        "H1XWeek3": ["H1", "21", "Most Directed [M]"],
+        "H1XWeek5": ["H1", "35", "Most Directed [M]"],
+        "H1SWeek5": ["H1", "35", "Least Direct [L]"],
+        "H1SWeek8": ["H1", "56", "Least Direct [L]"],
+        "H1XWeek8": ["H1", "56", "Most Directed [M]"],
+        "H1XWeek10": ["H1", "70", "Most Directed [M]"],
+        "H1SWeek10": ["H1", "70", "Least Direct [L]"],
+        "H1SWeek24": ["H1", "168", "Protocol [L]"],  # male, GEO name is wk24H1S_S2
+        "H28126SWeek3": ["H28126", "21", "Least Direct [L]"],  # male
+        "H28126XWeek3": ["H28126", "21", "Most Directed [M]"],
+        "H28126SWeek5": ["H28126", "35", "Least Direct [L]"],
+        "H28126XWeek5": ["H28126", "35", "Most Directed [M]"],
+        "H28126PWeek5": ["H28126", "35", "Directed [D]"],
+        "H28126S2Week5": ["H28126", "35", "Least Direct [L]"],  #hES-derived cerebral organoid
+        "H28126SWeek8": ["H28126", "56", "Least Direct [L]"],
+        "H28126XWeek8": ["H28126", "56", "Most Directed [M]"],
+        "H28126S2Week8": ["H28126", "56", "Least Direct [L]"],
+        "H28126PWeek8": ["H28126", "56", "Directed [D]"],
+        "H28126SWeek10": ["H28126", "70", "Least Direct [L]"],
+        "H28126XWeek10": ["H28126", "70", "Most Directed [M]"],
+        "H28126S2Week10": ["H28126", "70", " Least Direct [L]"],
+        "YH10SWeek5": ["WTC10", "35", "Least Direct [L]"],  # male
+        "YH10PWeek5": ["WTC10", "35", "Directed [D]"],
+        "YH10SWeek8": ["WTC10", "56", "Least Direct [L]"],
+        "YH10PWeek8": ["WTC10", "56", "Directed [D]"],
+        "YH10PWeek10": ["WTC10", "70", "Directed [D]"],
+        "YH10SWeek10": ["WTC10", "70", "Least Direct [L]"],
+        "Week5S_1323_4": ["1323_4", "35", "Least Direct [L]"],  # female
+        "Week5P_1323_4": ["1323_4", "35", "Directed [D]"],
+        "Week8S_1323_4": ["1323_4", "56", "Least Direct [L]"],
+        "Week8P_1323_4": ["1323_4", "56", "Directed [D]"],
+        "Week10S_1323_4": ["1323_4", "70", "Least Direct [L]"],
+        "Week10P_1323_4": ["1323_4", "70", "Directed [D]"],
+        "L13234PWeek24": ["1323_4", "168", "Directed [D]"],  #GEO wk2413234P, female; I think this is 1323_4
+        "L13234SWeek24": ["1323_4", "168", "Least Direct [L]"],  # GEO wk2413234S, female; I think this is 1323_4
+        "L13234SWeek15": ["1323_4", "105", "Least Direct [L]"],  # male, 10x v2, in GEO says its age is 24 weeks, but the name suggests 15 weeks?    
+    }
+    fn = os.path.join(data_dir, "GSE132672_allorganoids_withnew_matrix.txt.gz")
+    df = pd.read_csv(fn, delimiter='\t', compression='gzip', index_col=0)
+    adata = ad.AnnData(df.T)
+    adata.obs['sample'] = df.columns.str.slice(stop=-17)
+    adata.obs[["cell_line", "organoid_age_day", "protocol"]] = [dic[i] for i in adata.obs['sample']]
+
+    return adata

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001.py
@@ -45,8 +45,8 @@ def load(data_dir, **kwargs):
         "Week10P_1323_4": ["1323_4", "70", "Directed [D]"],
         "L13234PWeek24": ["1323_4", "168", "Directed [D]"],  # GEO wk2413234P, female; I think this is 1323_4
         "L13234SWeek24": ["1323_4", "168", "Least Direct [L]"],  # GEO wk2413234S, female; I think this is 1323_4
-        "L13234SWeek15": ["1323_4", "105", "Least Direct [L]"]  # male, 10x v2, in GEO says its age is 24 weeks, but the name suggests 15 weeks?    
-    }
+        "L13234SWeek15": ["1323_4", "105", "Least Direct [L]"]}  # male, 10x v2, in GEO says its age is 24 weeks, but the name suggests 15 weeks?    
+
     fn = os.path.join(data_dir, "GSE132672_allorganoids_withnew_matrix.txt.gz")
     df = pd.read_csv(fn, delimiter='\t', compression='gzip', index_col=0)
     adata = ad.AnnData(df.T)

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001.py
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001.py
@@ -23,7 +23,7 @@ def load(data_dir, **kwargs):
         "H28126SWeek5": ["H28126", "35", "Least Direct [L]"],
         "H28126XWeek5": ["H28126", "35", "Most Directed [M]"],
         "H28126PWeek5": ["H28126", "35", "Directed [D]"],
-        "H28126S2Week5": ["H28126", "35", "Least Direct [L]"],  #hES-derived cerebral organoid
+        "H28126S2Week5": ["H28126", "35", "Least Direct [L]"],  # hES-derived cerebral organoid
         "H28126SWeek8": ["H28126", "56", "Least Direct [L]"],
         "H28126XWeek8": ["H28126", "56", "Most Directed [M]"],
         "H28126S2Week8": ["H28126", "56", "Least Direct [L]"],
@@ -43,9 +43,9 @@ def load(data_dir, **kwargs):
         "Week8P_1323_4": ["1323_4", "56", "Directed [D]"],
         "Week10S_1323_4": ["1323_4", "70", "Least Direct [L]"],
         "Week10P_1323_4": ["1323_4", "70", "Directed [D]"],
-        "L13234PWeek24": ["1323_4", "168", "Directed [D]"],  #GEO wk2413234P, female; I think this is 1323_4
+        "L13234PWeek24": ["1323_4", "168", "Directed [D]"],  # GEO wk2413234P, female; I think this is 1323_4
         "L13234SWeek24": ["1323_4", "168", "Least Direct [L]"],  # GEO wk2413234S, female; I think this is 1323_4
-        "L13234SWeek15": ["1323_4", "105", "Least Direct [L]"],  # male, 10x v2, in GEO says its age is 24 weeks, but the name suggests 15 weeks?    
+        "L13234SWeek15": ["1323_4", "105", "Least Direct [L]"]  # male, 10x v2, in GEO says its age is 24 weeks, but the name suggests 15 weeks?    
     }
     fn = os.path.join(data_dir, "GSE132672_allorganoids_withnew_matrix.txt.gz")
     df = pd.read_csv(fn, delimiter='\t', compression='gzip', index_col=0)

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001.yaml
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001.yaml
@@ -1,25 +1,34 @@
 dataset_structure:
     dataset_index: 1
     sample_fns:
+        - "organoids"
+        - "primary"
 dataset_wise:
     author: "Bhaduri, Aparna"
-    default_embedding: 
+    default_embedding:
+        primary: "X_tsne"
     doi_preprint: 
     doi_journal: "10.1038/s41586-020-1962-0"
-    download_url_data: "https://ftp.ncbi.nlm.nih.gov/geo/series/GSE132nnn/GSE132672/suppl/GSE132672%5Fallorganoids%5Fwithnew%5Fmatrix%2Etxt%2Egz"
+    download_url_data: 
+        organoids: "https://cells.ucsc.edu/organoidreportcard/organoids10X/organoidsmatrix_nonorm.txt.gz"
+        primary: "https://cells.ucsc.edu/organoidreportcard/primary10X/primarymatrix_nonorm.txt.gz"
     download_url_meta: 
+        organoids: "https://static-content.springer.com/esm/art%3A10.1038%2Fs41586-020-1962-0/MediaObjects/41586_2020_1962_MOESM3_ESM.xlsx"
+        primary: 
+            - "https://cells.ucsc.edu/organoidreportcard/primary10X/meta.tsv"
+            - "https://cells.ucsc.edu/organoidreportcard/primary10X/Seurat_tsne.coords.tsv.gz"
     primary_data: True
     year: 2020
 layers:
-    layer_counts: 
-    layer_processed: "X"
+    layer_counts: "X"
+    layer_processed: 
     layer_spliced_counts: 
     layer_spliced_processed: 
     layer_unspliced_counts: 
     layer_unspliced_processed: 
     layer_velocity: 
 dataset_or_feature_wise:
-    feature_reference: "Homo_sapiens.GRCh38.104"
+    feature_reference: "Homo_sapiens.GRCh38.83"
     feature_reference_var_key: 
     feature_type: "rna"
     feature_type_var_key: 
@@ -27,17 +36,22 @@ dataset_or_observation_wise:
     assay_sc: "10x 3' v2"
     assay_sc_obs_key: 
     assay_differentiation: 
-    assay_differentiation_obs_key: "protocol"
+    assay_differentiation_obs_key: 
+        organoids: "Protocol"
     assay_type_differentiation: 
-    assay_type_differentiation_obs_key: "protocol"
+    assay_type_differentiation_obs_key:
+        organoids: "assay_type_diff"
     bio_sample:
-    bio_sample_obs_key: "sample"
+    bio_sample_obs_key:
+        orgnoids: "Sample"
+        primary: "Area*Individual"
     cell_line: 
-    cell_line_obs_key: "cell_line"
+    cell_line_obs_key:
+        organoids: "Line"
     cell_type: 
-    cell_type_obs_key: 
+    cell_type_obs_key: "celltype"
     development_stage: 
-    development_stage_obs_key: "organoid_age_day"
+    development_stage_obs_key: "Age"
     disease: "healthy"
     disease_obs_key: 
     ethnicity: 
@@ -46,14 +60,20 @@ dataset_or_observation_wise:
     gm_obs_key:
     individual:
     individual_obs_key: 
-    organ: "forebrain"
+        primary: "Individual"
+    organ: 
     organ_obs_key: 
+        organoids: "Protocol"
+        primary: "Area"
     organism: "Homo sapiens"
     organism_obs_key: 
-    sample_source: "3d_culture"  # TODO: Add primary data
+    sample_source:
+        organoids: "3d_culture"
+        primary: "primary_tissue"
     sample_source_obs_key: 
     sex: 
-    sex_obs_key: "cell_line"
+    sex_obs_key:
+        organoids: "Line"
     source_doi:
     source_doi_obs_key:
     state_exact:

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001.yaml
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001.yaml
@@ -1,0 +1,89 @@
+dataset_structure:
+    dataset_index: 1
+    sample_fns:
+dataset_wise:
+    author: "Bhaduri, Aparna"
+    default_embedding: 
+    doi_preprint: 
+    doi_journal: "10.1038/s41586-020-1962-0"
+    download_url_data: "https://ftp.ncbi.nlm.nih.gov/geo/series/GSE132nnn/GSE132672/suppl/GSE132672%5Fallorganoids%5Fwithnew%5Fmatrix%2Etxt%2Egz"
+    download_url_meta: 
+    primary_data: True
+    year: 2020
+layers:
+    layer_counts: 
+    layer_processed: "X"
+    layer_spliced_counts: 
+    layer_spliced_processed: 
+    layer_unspliced_counts: 
+    layer_unspliced_processed: 
+    layer_velocity: 
+dataset_or_feature_wise:
+    feature_reference: "Homo_sapiens.GRCh38.104"
+    feature_reference_var_key: 
+    feature_type: "rna"
+    feature_type_var_key: 
+dataset_or_observation_wise:
+    assay_sc: "10x 3' v2"
+    assay_sc_obs_key: 
+    assay_differentiation: 
+    assay_differentiation_obs_key: "protocol"
+    assay_type_differentiation: 
+    assay_type_differentiation_obs_key: "protocol"
+    bio_sample:
+    bio_sample_obs_key: "sample"
+    cell_line: 
+    cell_line_obs_key: "cell_line"
+    cell_type: 
+    cell_type_obs_key: 
+    development_stage: 
+    development_stage_obs_key: "organoid_age_day"
+    disease: "healthy"
+    disease_obs_key: 
+    ethnicity: 
+    ethnicity_obs_key: 
+    gm:
+    gm_obs_key:
+    individual:
+    individual_obs_key: 
+    organ: "forebrain"
+    organ_obs_key: 
+    organism: "Homo sapiens"
+    organism_obs_key: 
+    sample_source: "3d_culture"  # TODO: Add primary data
+    sample_source_obs_key: 
+    sex: 
+    sex_obs_key: "cell_line"
+    source_doi:
+    source_doi_obs_key:
+    state_exact:
+    state_exact_obs_key:
+    suspension_type: "cell"
+    suspension_type_obs_key: 
+    tech_sample:
+    tech_sample_obs_key: 
+    treatment:
+    treatment_obs_key:
+feature_wise:
+    feature_id_var_key: 
+    feature_symbol_var_key: "index"
+observation_wise:
+    spatial_x_coord_obs_key: 
+    spatial_y_coord_obs_key: 
+    spatial_z_coord_obs_key: 
+    vdj_vj_1_obs_key_prefix: 
+    vdj_vj_2_obs_key_prefix: 
+    vdj_vdj_1_obs_key_prefix: 
+    vdj_vdj_2_obs_key_prefix: 
+    vdj_c_call_obs_key_suffix: 
+    vdj_consensus_count_obs_key_suffix: 
+    vdj_d_call_obs_key_suffix: 
+    vdj_duplicate_count_obs_key_suffix: 
+    vdj_j_call_obs_key_suffix: 
+    vdj_junction_obs_key_suffix: 
+    vdj_junction_aa_obs_key_suffix: 
+    vdj_locus_obs_key_suffix: 
+    vdj_productive_obs_key_suffix: 
+    vdj_v_call_obs_key_suffix: 
+meta:
+    version: "1.2"

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001_cell_line.tsv
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001_cell_line.tsv
@@ -1,5 +1,5 @@
-source	target
-1323_4	eWT-1323-4
-H1	WA01
-H28126	custom_H28126
-WTC10	custom_WTC10
+source	target	target_id
+1323_4	eWT-1323-4	CVCL_0G84
+H1	WA01	CVCL_9771
+H28126	custom_H28126	unknown
+YH10	GM25256	CVCL_Y803

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001_cell_line.tsv
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001_cell_line.tsv
@@ -1,0 +1,5 @@
+source	target
+1323_4	eWT-1323-4
+H1	WA01
+H28126	custom_H28126
+WTC10	custom_WTC10

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001_cell_type.tsv
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001_cell_type.tsv
@@ -1,0 +1,45 @@
+source	target	target_id
+Astrocyte_Astrocyte	mature astrocyte	CL:0002627
+Endothelial_Endothelial	endothelial cell	CL:0000115
+Excitatory Neuron _Cajal Retzius	Cajal-Retzius cell	CL:0000695
+Excitatory Neuron _Deep Layer	cerebral cortex pyramidal neuron	CL:4023111
+Excitatory Neuron _IPC/newborn	neuroblast (sensu Vertebrata)	CL:0000031
+Excitatory Neuron _Layer IV	cerebral cortex pyramidal neuron	CL:4023111
+Excitatory Neuron _Layer VI Occipital	L6b glutamatergic cortical neuron	CL:4023038
+Excitatory Neuron _Layer VI Pan-area	L6b glutamatergic cortical neuron	CL:4023038
+Excitatory Neuron _Low Quality	glutamatergic neuron	CL:0000679
+Excitatory Neuron _Newborn	glutamatergic neuron	CL:0000679
+Excitatory Neuron _PFC	cerebral cortex pyramidal neuron	CL:4023111
+Excitatory Neuron _Pan-neuronal	glutamatergic neuron	CL:0000679
+Excitatory Neuron _Parietal and Temporal	cerebral cortex pyramidal neuron	CL:4023111
+Excitatory Neuron _Upper Layer	cerebral cortex pyramidal neuron	CL:4023111
+Excitatory Neuron _Upper Layer Occipital	cerebral cortex pyramidal neuron	CL:4023111
+Excitatory Neuron _Upper Layer PFC	cerebral cortex pyramidal neuron	CL:4023111
+Excitatory Neuron _V1 Neurons	cerebral cortex pyramidal neuron	CL:4023111
+Excitatory Neuron_Low quality	glutamatergic neuron	CL:0000679
+Excitatory Neuron_Newborn Low-Quality	glutamatergic neuron	CL:0000679
+Excitatory Neuron_Pan-neuronal	glutamatergic neuron	CL:0000679
+IPC_IPC-div1	neuroblast (sensu Vertebrata)	CL:0000031
+IPC_IPC-div2	neuroblast (sensu Vertebrata)	CL:0000031
+IPC_IPC-new	neuroblast (sensu Vertebrata)	CL:0000031
+Inhibitory Neuron_MGE2	medial ganglionic eminence derived GABAergic cortical interneuron	CL:4023069
+Inhibitory Neuron_SST-MGE1	sst GABAergic cortical interneuron	CL:4023017
+Microglia_Microglia	microglial cell	CL:0000129
+Microglia_Microglia low quality	microglial cell	CL:0000129
+Mixed Neuron/Radial Glia_Mixed	neural cell	CL:0002319
+Mural_Mural	mural cell	CL:0008034
+OPC_OPC	oligodendrocyte precursor cell	CL:0002453
+Outlier_Outlier	unknown	unknown
+Radial Glia_Glycolytic RG	radial glial cell	CL:0000681
+Radial Glia_Hindbrain RG	radial glial cell	CL:0000681
+Radial Glia_Low Quality	radial glial cell	CL:0000681
+Radial Glia_Low quality	radial glial cell	CL:0000681
+Radial Glia_Pan-radial glia	radial glial cell	CL:0000681
+Radial Glia_early	radial glial cell	CL:0000681
+Radial Glia_late	radial glial cell	CL:0000681
+Radial Glia_oRG	radial glial cell	CL:0000681
+Radial Glia_oRG/Astrocyte	immature astrocyte	CL:0002626
+Radial Glia_tRG	radial glial cell	CL:0000681
+Radial Glia_vRG	radial glial cell	CL:0000681
+Red blood cells_Low Quality	erythrocyte	CL:0000232
+Unknown_Unknown	unknown	unknown

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001_development_stage.tsv
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001_development_stage.tsv
@@ -1,7 +1,11 @@
 source	target	target_id
-105	15th week post-fertilization human stage	HsapDv:0000052
-168	24th week post-fertilization human stage	HsapDv:0000061
-21	Carnegie stage 09	HsapDv:0000016
-35	Carnegie stage 15	HsapDv:0000022
-56	Carnegie stage 22	HsapDv:0000029
-70	10th week post-fertilization human stage	HsapDv:0000047
+3	Carnegie stage 09	HsapDv:0000016
+5	Carnegie stage 15	HsapDv:0000022
+6	Carnegie stage 17	HsapDv:0000024
+8	Carnegie stage 22	HsapDv:0000029
+10	10th week post-fertilization human stage	HsapDv:0000047
+14	14th week post-fertilization human stage	HsapDv:0000051
+15	15th week post-fertilization human stage	HsapDv:0000052
+18	18th week post-fertilization human stage	HsapDv:0000055
+22	22nd week post-fertilization human stage	HsapDv:0000059
+24	24th week post-fertilization human stage	HsapDv:0000061

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001_development_stage.tsv
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001_development_stage.tsv
@@ -1,0 +1,7 @@
+source	target	target_id
+105	15th week post-fertilization human stage	HsapDv:0000052
+168	24th week post-fertilization human stage	HsapDv:0000061
+21	Carnegie stage 09	HsapDv:0000016
+35	Carnegie stage 15	HsapDv:0000022
+56	Carnegie stage 22	HsapDv:0000029
+70	10th week post-fertilization human stage	HsapDv:0000047

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001_organ.tsv
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001_organ.tsv
@@ -1,0 +1,15 @@
+source	target	target_id
+Central cortex	cerebral cortex	UBERON:0000956
+Directed	cerebral cortex	UBERON:0000956
+Frontal cortex	frontal cortex	UBERON:0001870
+Least Directed	brain	UBERON:0000955
+Most Directed	cerebral cortex	UBERON:0000956
+Occipital cortex	occipital cortex	UBERON:0016540
+PFC	prefrontal cortex	UBERON:0000451
+Telencephalon	telencephalon	UBERON:0001893
+V1	primary visual cortex	UBERON:0002436
+hippocampus	hippocampal formation	UBERON:0002421
+motor	primary motor cortex	UBERON:0001384
+parietal	parietal cortex	UBERON:0016530
+somatosensory	somatosensory cortex	UBERON:0008930
+temporal	temporal cortex	UBERON:0016538

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001_sex.tsv
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001_sex.tsv
@@ -2,4 +2,4 @@ source	target	target_id
 1323_4	female	PATO:0000383
 H1	male	PATO:0000384
 H28126	male	PATO:0000384
-WTC10	male	PATO:0000384
+YH10	male	PATO:0000384

--- a/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001_sex.tsv
+++ b/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001_sex.tsv
@@ -1,0 +1,5 @@
+source	target	target_id
+1323_4	female	PATO:0000383
+H1	male	PATO:0000384
+H28126	male	PATO:0000384
+WTC10	male	PATO:0000384


### PR DESCRIPTION
/lustre/groups/ml01/code/irena.sliskovic/sfaira/sfaira/data/dataloaders/loaders/d10_1038_s41586_020_1962_0/homosapiens_forebrain_2020_10x3v2_bhaduri_001.py:52: FutureWarning: X.dtype being converted to np.float32 from float64. In the next version of anndata (0.9) conversion will not be automatic. Pass dtype explicitly to avoid this warning. Pass `AnnData(X, dtype=X.dtype, ...)` to get the future behavour.
  adata = ad.AnnData(df.T)
/lustre/groups/ml01/code/irena.sliskovic/sfaira/sfaira/versions/genomes/genomes.py:198: DtypeWarning: Columns (0) have mixed types.Specify dtype option on import or set low_memory=False.
  self.load_genome()
transformed feature space on homosapiens_forebrain_2020_10x3v2_bhaduriaparna_001_d10_1038_s41586_020_1962_0: 
log10 total counts 10.4 to 10.37, non-zero features 16774 to 14265
2023-02-28 14:29:20.890929: W tensorflow/stream_executor/platform/default/dso_loader.cc:64] Could not load dynamic library 'libcudart.so.11.0'; dlerror: libcudart.so.11.0: cannot open shared object file: No such file or directory; LD_LIBRARY_PATH: /opt/R/lib/R/lib
2023-02-28 14:29:20.891017: I tensorflow/stream_executor/cuda/cudart_stub.cc:29] Ignore above cudart dlerror if you do not have a GPU set up on your machine.
Completed testing of data loader, the data loader is now ready for use.
Sfaira butler: "You data loader is finished!"
               "Proceed to phase 4 (publish) or use data loader."
               "Copy the following lines as a post into the pull request:"
=========================
Data loader test passed:
    - homosapiens_forebrain_2020_10x3v2_bhaduriaparna_001_d10_1038_s41586_020_1962_0
=========================